### PR TITLE
feat: add dsl checker

### DIFF
--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -1,0 +1,182 @@
+import * as _ from "lodash";
+
+import { Keywords } from "./keywords";
+import { parseDSL } from "./parse-dsl";
+import { report } from "./reporters";
+
+const readTypeData = (r: any, lines: any) => {
+  const typeName = _.trim(_.flattenDeep(r[0][2]).join(""));
+  const typeDefinition = _.flattenDeep([r[0][1], r[0][2]]).join("");
+  const typeDefinitionLine = _.findIndex(lines, (l: string) => _.trim(l) === typeDefinition) + 1;
+  return { typeName, typeDefinition, typeDefinitionLine };
+};
+
+export const checkDSL = (codeInEditor: string) => {
+  const lines = codeInEditor.split("\n");
+  const markers: any = [];
+  const reporter = report({ lines, markers });
+
+  try {
+    const results = parseDSL(codeInEditor);
+    const relationsPerType: Record<string, string[]> = {};
+    const globalRelations = [Keywords.SELF as string];
+
+    // Reading relations per type
+    _.forEach(results, (r) => {
+      const { typeName, typeDefinitionLine } = readTypeData(r, lines);
+
+      // Include keyword
+      const relations = [Keywords.SELF as string];
+
+      _.forEach(r[2], (r2, idx: number) => {
+        const relation = _.trim(_.flattenDeep(r2).join("")).match(/define\s+(.*)\s+as/)?.[1];
+        if (!relation) {
+          return;
+        }
+        const lineIdx = typeDefinitionLine + idx + 1;
+
+        if (relations.includes(relation)) {
+          reporter.duplicateDefinition({ lineIndex: lineIdx, value: relation });
+        }
+
+        relations.push(relation);
+        globalRelations.push(relation);
+      });
+
+      relationsPerType[typeName] = relations;
+    });
+
+    _.forEach(results, (r) => {
+      const { typeName, typeDefinitionLine } = readTypeData(r, lines);
+
+      _.forEach(r[2], (r2, idx: number) => {
+        const lineIndex = typeDefinitionLine + idx + 1;
+        let definition: any[] = _.flatten(r2[0][1]);
+
+        if (!definition[0].includes(Keywords.DEFINE)) {
+          definition = _.flatten(definition);
+        }
+
+        const definitionName = _.flattenDeep(definition[2]).join("");
+
+        if (definition[0].includes(Keywords.DEFINE)) {
+          const clauses = _.slice(definition, 7, definition.length);
+
+          _.forEach(clauses, (clause) => {
+            let value = _.trim(_.flattenDeep(clause).join(""));
+
+            if (value.indexOf(Keywords.OR) === 0) {
+              value = value.replace(`${Keywords.OR} `, "");
+            }
+
+            if (value.indexOf(Keywords.AND) === 0) {
+              value = value.replace(`${Keywords.AND} `, "");
+            }
+
+            const hasFrom = value.includes(Keywords.FROM);
+            const hasButNot = value.includes(Keywords.BUT_NOT);
+
+            if (hasButNot) {
+              const butNotValue = _.trim(_.last(value.split(Keywords.BUT_NOT)));
+
+              if (definitionName === butNotValue) {
+                reporter.invalidButNot({
+                  lineIndex,
+                  value: butNotValue,
+                  clause: value,
+                });
+              } else {
+                reporter.invalidRelationWithinClause({
+                  typeName,
+                  value: butNotValue,
+                  validRelations: relationsPerType,
+                  clause: value,
+                  reverse: true,
+                  lineIndex,
+                });
+              }
+            } else if (hasFrom) {
+              // Checking: `define share as owner from parent`
+              const values = value.split(Keywords.FROM).map((v) => _.trim(v));
+
+              reporter.invalidRelationWithinClause({
+                typeName,
+                reverse: false,
+                value: values[0],
+                validRelations: globalRelations,
+                clause: value,
+                lineIndex,
+              });
+
+              if (definitionName === values[1]) {
+                // Checking: `define owner as writer from owner`
+                if (clauses.length < 2) {
+                  reporter.invalidFrom({
+                    lineIndex,
+                    value: values[1],
+                    clause: value,
+                  });
+                }
+              } else {
+                reporter.invalidRelationWithinClause({
+                  typeName,
+                  value: values[1],
+                  validRelations: relationsPerType,
+                  clause: value,
+                  reverse: true,
+                  lineIndex,
+                });
+              }
+            } else if (definitionName === value) {
+              // Checking: `define owner as owner`
+              reporter.useSelf({
+                lineIndex,
+                value,
+              });
+            } else {
+              // Checking: `define owner as self`
+              reporter.invalidRelation({
+                lineIndex,
+                value,
+                validRelations: globalRelations,
+              });
+            }
+          });
+        }
+      });
+    });
+  } catch (e: any) {
+    if (!_.isUndefined(e.offset)) {
+      const line = Number.parseInt(e.message.match(/line\s([0-9]*)\scol\s([0-9]*)/m)[1]);
+      const column = Number.parseInt(e.message.match(/line\s([0-9]*)\scol\s([0-9]*)/m)[2]);
+
+      const marker = {
+        // monaco.MarkerSeverity.Error,
+        severity: 8,
+        startColumn: column - 1,
+        endColumn: lines[line - 1].length,
+        startLineNumber: column === 0 ? line - 1 : line,
+        endLineNumber: column === 0 ? line - 1 : line,
+        message: "Invalid syntax",
+        source: "linter",
+      };
+
+      markers.push(marker);
+    } else {
+      const marker = {
+        // monaco.MarkerSeverity.Error,
+        severity: 8,
+        startColumn: 0,
+        endColumn: Number.MAX_SAFE_INTEGER,
+        startLineNumber: 0,
+        endLineNumber: lines.length,
+        message: "Invalid syntax",
+        source: "linter",
+      };
+
+      markers.push(marker);
+    }
+  }
+
+  return markers;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { friendlySyntaxToApiSyntax } from "./friendly-to-api";
 export { apiSyntaxToFriendlySyntax } from "./api-to-friendly";
+export { checkDSL } from "./check-dsl";

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -1,0 +1,213 @@
+import * as _ from "lodash";
+
+import { Keywords } from "./keywords";
+
+interface BaseReporterOpts {
+  markers: any;
+  lines: string[];
+  lineIndex: number;
+  value: string;
+}
+
+interface ReporterOpts extends BaseReporterOpts {
+  validRelations?: string[] | Record<string, string[]>;
+  clause?: any;
+  typeName?: string;
+  reverse?: boolean;
+}
+
+interface ErrorReporterOpts extends BaseReporterOpts {
+  message: string;
+  customResolver?: (wordIdx: number, rawLine: string, value: string) => number;
+  relatedInformation?: {
+    type: string;
+  }
+}
+
+const getValidRelationsArray = (validRelations?: string[] | Record<string, string[]>, typeName?: string): string[] => {
+  if (!validRelations) {
+    return [];
+  }
+  return Array.isArray(validRelations) ?
+    validRelations : typeName ? validRelations?.[typeName] : [];
+};
+
+const reportError = ({
+  markers,
+  lines,
+  lineIndex,
+  message,
+  value,
+  customResolver = undefined,
+  relatedInformation = { type: "" },
+}: ErrorReporterOpts) => {
+  const rawLine = lines[lineIndex];
+
+  const asIdx = rawLine.indexOf("as") + 1;
+  const definition = _.last(rawLine.split("as"))!;
+  let wordIdx = asIdx + definition.indexOf(value) + 2;
+
+  if (_.isFunction(customResolver)) {
+    wordIdx = customResolver(wordIdx, rawLine, value);
+  }
+
+  markers.push({
+    relatedInformation,
+    // monaco.MarkerSeverity.Error,
+    severity: 8,
+    startColumn: wordIdx,
+    endColumn: wordIdx + value.length,
+    startLineNumber: lineIndex + 1,
+    endLineNumber: lineIndex + 1,
+    message,
+    source: "linter",
+  });
+};
+
+export const reportUseSelf = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  reportError({
+    message: "For auto-referencing use `self`.",
+    markers,
+    lines,
+    value,
+    relatedInformation: { type: "self-error" },
+    lineIndex,
+  });
+};
+
+export const reportInvalidFrom = ({ markers, lines, lineIndex, value, clause }: ReporterOpts) => {
+  reportError({
+    message: `Cannot self-reference (\`${value}\`) within \`from\` clause.`,
+    markers,
+    lines,
+    value,
+    lineIndex,
+    customResolver: (wordIdx, rawLine, value) => {
+      const fromStartsAt = rawLine.indexOf(clause);
+      wordIdx = fromStartsAt + rawLine.slice(fromStartsAt, fromStartsAt + clause.length).lastIndexOf(value) + 1;
+
+      return wordIdx;
+    },
+  });
+};
+
+export const reportInvalidButNot = ({ markers, lines, lineIndex, value, clause }: ReporterOpts) => {
+  reportError({
+    message: `Cannot self-reference (\`${value}\`) within \`but not\` clause.`,
+    markers,
+    lineIndex,
+    lines,
+    value,
+    customResolver: (wordIdx, rawLine, value) => {
+      const fromStartsAt = rawLine.indexOf(clause);
+      wordIdx = fromStartsAt + rawLine.slice(fromStartsAt, fromStartsAt + clause.length).lastIndexOf(value) + 1;
+
+      return wordIdx;
+    },
+  });
+};
+export const reportInvalidRelationWithinClause = ({
+  markers,
+  lines,
+  lineIndex,
+  typeName,
+  value,
+  validRelations,
+  clause,
+  reverse = false,
+}: ReporterOpts) => {
+  const data = getValidRelationsArray(validRelations, typeName);
+  const isInValid = !data?.includes(value);
+
+  if (isInValid) {
+    reportError({
+      message: `The relation \`${value}\` does not exist${
+        Array.isArray(validRelations) ? "." : ` in type \`${typeName}\``
+      }`,
+      markers,
+      lines,
+      value,
+      lineIndex,
+      customResolver: (wordIdx, rawLine, value) => {
+        const clauseStartsAt = rawLine.indexOf(clause);
+        wordIdx = clauseStartsAt + rawLine.slice(clauseStartsAt, clauseStartsAt + clause.length).indexOf(value) + 1;
+
+        if (reverse) {
+          wordIdx =
+            clauseStartsAt + rawLine.slice(clauseStartsAt, clauseStartsAt + clause.length).lastIndexOf(value) + 1;
+        }
+
+        return wordIdx;
+      },
+    });
+  }
+};
+
+export const reportInvalidRelation = ({ markers, lines, lineIndex, value, validRelations }: ReporterOpts) => {
+  const data = getValidRelationsArray(validRelations);
+  const isInValid = !data?.includes(value);
+  if (isInValid) {
+    reportError({
+      markers,
+      lines,
+      lineIndex,
+      value,
+      message: `The relation \`${value}\` does not exist.`,
+      relatedInformation: { type: "missing-definition", relation: value } as any,
+    });
+  }
+};
+
+export const reportDuplicate = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  const rawLine = lines[lineIndex];
+
+  markers.push({
+    relatedInformation: { type: "duplicated-error" },
+    // monaco.MarkerSeverity.Error,
+    severity: 8,
+    startColumn: rawLine.indexOf(Keywords.DEFINE) + 1,
+    endColumn: rawLine.length + 1,
+    startLineNumber: lineIndex + 1,
+    endLineNumber: lineIndex + 1,
+    message: `Duplicate definition \`${value}\`.`,
+    source: "linter",
+  });
+};
+
+export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "markers" | "lines">) {
+  return {
+    useSelf: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportUseSelf({ value, lineIndex, markers, lines }),
+
+    invalidFrom: ({ lineIndex, value, clause }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportInvalidFrom({ value, clause, lineIndex, markers, lines }),
+
+    invalidButNot: ({ lineIndex, value, clause }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportInvalidButNot({ lineIndex, value, clause, markers, lines }),
+
+    duplicateDefinition: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportDuplicate({ lineIndex, value, markers, lines }),
+
+    invalidRelation: ({ lineIndex, value, validRelations }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportInvalidRelation({
+        lineIndex,
+        value,
+        validRelations,
+        markers,
+        lines,
+      }),
+
+    invalidRelationWithinClause:
+      ({ lineIndex, value, typeName, validRelations, clause, reverse }: Omit<ReporterOpts, "markers" | "lines">) =>
+        reportInvalidRelationWithinClause({
+          lineIndex,
+          value,
+          typeName,
+          validRelations,
+          clause,
+          reverse,
+          markers,
+          lines,
+        }),
+  };
+};

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -1,0 +1,2784 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DSL checkDSL() invalid code should handle \`no definitions\` 1`] = `
+Array [
+  Object {
+    "endColumn": 9007199254740991,
+    "endLineNumber": 2,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 0,
+    "startLineNumber": 0,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid code should handle \`no relations\` 1`] = `
+Array [
+  Object {
+    "endColumn": 9007199254740991,
+    "endLineNumber": 1,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 0,
+    "startLineNumber": 0,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`and\` 1`] = `
+Array [
+  Object {
+    "endColumn": 37,
+    "endLineNumber": 4,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 28,
+    "startLineNumber": 4,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`as\` 1`] = `
+Array [
+  Object {
+    "endColumn": 26,
+    "endLineNumber": 3,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 19,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`as\` 2`] = `
+Array [
+  Object {
+    "endColumn": 26,
+    "endLineNumber": 3,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 19,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`but not\` 1`] = `
+Array [
+  Object {
+    "endColumn": 41,
+    "endLineNumber": 4,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 32,
+    "startLineNumber": 4,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`define\` 1`] = `
+Array [
+  Object {
+    "endColumn": 27,
+    "endLineNumber": 3,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 6,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`or\` 1`] = `
+Array [
+  Object {
+    "endColumn": 36,
+    "endLineNumber": 4,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 27,
+    "startLineNumber": 4,
+  },
+]
+`;
+
+exports[`DSL checkDSL() invalid keywords should handle invalid \`self\` 1`] = `
+Array [
+  Object {
+    "endColumn": 26,
+    "endLineNumber": 3,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 24,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should allow self reference 1`] = `Array []`;
+
+exports[`DSL checkDSL() semantics should be able to handle more than one error 1`] = `
+Array [
+  Object {
+    "endColumn": 28,
+    "endLineNumber": 3,
+    "message": "For auto-referencing use \`self\`.",
+    "relatedInformation": Object {
+      "type": "self-error",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 22,
+    "startLineNumber": 3,
+  },
+  Object {
+    "endColumn": 33,
+    "endLineNumber": 5,
+    "message": "The relation \`relation2\` does not exist.",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 24,
+    "startLineNumber": 5,
+  },
+  Object {
+    "endColumn": 48,
+    "endLineNumber": 5,
+    "message": "The relation \`relation2\` does not exist in type \`group\`",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 39,
+    "startLineNumber": 5,
+  },
+  Object {
+    "endColumn": 55,
+    "endLineNumber": 6,
+    "message": "Cannot self-reference (\`domain\`) within \`but not\` clause.",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 49,
+    "startLineNumber": 6,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle duplicated definition 1`] = `
+Array [
+  Object {
+    "endColumn": 26,
+    "endLineNumber": 4,
+    "message": "Duplicate definition \`writer\`.",
+    "relatedInformation": Object {
+      "type": "duplicated-error",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 5,
+    "startLineNumber": 4,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`invalid and\` 1`] = `
+Array [
+  Object {
+    "endColumn": 37,
+    "endLineNumber": 3,
+    "message": "The relation \`reader\` does not exist.",
+    "relatedInformation": Object {
+      "relation": "reader",
+      "type": "missing-definition",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 31,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`invalid but not\` 1`] = `
+Array [
+  Object {
+    "endColumn": 41,
+    "endLineNumber": 3,
+    "message": "The relation \`reader\` does not exist in type \`group\`",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 35,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`invalid from\` 1`] = `
+Array [
+  Object {
+    "endColumn": 36,
+    "endLineNumber": 3,
+    "message": "The relation \`reader\` does not exist.",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 30,
+    "startLineNumber": 3,
+  },
+  Object {
+    "endColumn": 46,
+    "endLineNumber": 3,
+    "message": "The relation \`test\` does not exist in type \`group\`",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 42,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`invalid or\` 1`] = `
+Array [
+  Object {
+    "endColumn": 36,
+    "endLineNumber": 3,
+    "message": "The relation \`reader\` does not exist.",
+    "relatedInformation": Object {
+      "relation": "reader",
+      "type": "missing-definition",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 30,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`relation not define\` 1`] = `
+Array [
+  Object {
+    "endColumn": 28,
+    "endLineNumber": 3,
+    "message": "The relation \`reader\` does not exist.",
+    "relatedInformation": Object {
+      "relation": "reader",
+      "type": "missing-definition",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 22,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`self-error\` 1`] = `
+Array [
+  Object {
+    "endColumn": 28,
+    "endLineNumber": 3,
+    "message": "For auto-referencing use \`self\`.",
+    "relatedInformation": Object {
+      "type": "self-error",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 22,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`self-ref in but not\` 1`] = `
+Array [
+  Object {
+    "endColumn": 41,
+    "endLineNumber": 3,
+    "message": "Cannot self-reference (\`writer\`) within \`but not\` clause.",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 35,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should not allow impossible self reference 1`] = `
+Array [
+  Object {
+    "endColumn": 40,
+    "endLineNumber": 3,
+    "message": "Cannot self-reference (\`member\`) within \`from\` clause.",
+    "relatedInformation": Object {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 34,
+    "startLineNumber": 3,
+  },
+]
+`;
+
+exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
+Array [
+  Array [
+    Array [
+      Array [],
+      Array [
+        "type",
+        Array [
+          Array [
+            " ",
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          null,
+          Array [
+            Array [
+              "t",
+            ],
+            Array [
+              "e",
+            ],
+            Array [
+              "a",
+            ],
+            Array [
+              "m",
+            ],
+          ],
+        ],
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [],
+      Array [
+        "  relations",
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "m",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "m",
+                  ],
+                  Array [
+                    "b",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+    ],
+  ],
+  Array [
+    Array [
+      Array [],
+      Array [
+        "type",
+        Array [
+          Array [
+            " ",
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          null,
+          Array [
+            Array [
+              "r",
+            ],
+            Array [
+              "e",
+            ],
+            Array [
+              "p",
+            ],
+            Array [
+              "o",
+            ],
+          ],
+        ],
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [],
+      Array [
+        "  relations",
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "d",
+                    ],
+                    Array [
+                      "m",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "n",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "r",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "p",
+                            ],
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "_",
+                            ],
+                            Array [
+                              "a",
+                            ],
+                            Array [
+                              "d",
+                            ],
+                            Array [
+                              "m",
+                            ],
+                            Array [
+                              "i",
+                            ],
+                            Array [
+                              "n",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      "from",
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "w",
+                            ],
+                            Array [
+                              "n",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "m",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "n",
+                    ],
+                    Array [
+                      "t",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "n",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        null,
+                        Array [
+                          Array [
+                            "a",
+                          ],
+                          Array [
+                            "d",
+                          ],
+                          Array [
+                            "m",
+                          ],
+                          Array [
+                            "i",
+                          ],
+                          Array [
+                            "n",
+                          ],
+                        ],
+                      ],
+                      Array [],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "o",
+                  ],
+                  Array [
+                    "w",
+                  ],
+                  Array [
+                    "n",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "r",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "d",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        null,
+                        Array [
+                          Array [
+                            "t",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                          Array [
+                            "i",
+                          ],
+                          Array [
+                            "a",
+                          ],
+                          Array [
+                            "g",
+                          ],
+                          Array [
+                            "e",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                        ],
+                      ],
+                      Array [
+                        " ",
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "r",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "p",
+                            ],
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "_",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "a",
+                            ],
+                            Array [
+                              "d",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      "from",
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "w",
+                            ],
+                            Array [
+                              "n",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "t",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "g",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        null,
+                        Array [
+                          Array [
+                            "w",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                          Array [
+                            "i",
+                          ],
+                          Array [
+                            "t",
+                          ],
+                          Array [
+                            "e",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                        ],
+                      ],
+                      Array [],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "w",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "t",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        null,
+                        Array [
+                          Array [
+                            "m",
+                          ],
+                          Array [
+                            "a",
+                          ],
+                          Array [
+                            "i",
+                          ],
+                          Array [
+                            "n",
+                          ],
+                          Array [
+                            "t",
+                          ],
+                          Array [
+                            "a",
+                          ],
+                          Array [
+                            "i",
+                          ],
+                          Array [
+                            "n",
+                          ],
+                          Array [
+                            "e",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                        ],
+                      ],
+                      Array [
+                        " ",
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "r",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "p",
+                            ],
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "_",
+                            ],
+                            Array [
+                              "w",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                            Array [
+                              "i",
+                            ],
+                            Array [
+                              "t",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      "from",
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "w",
+                            ],
+                            Array [
+                              "n",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+    ],
+  ],
+  Array [
+    Array [
+      Array [],
+      Array [
+        "type",
+        Array [
+          Array [
+            " ",
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          null,
+          Array [
+            Array [
+              "o",
+            ],
+            Array [
+              "r",
+            ],
+            Array [
+              "g",
+            ],
+          ],
+        ],
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [],
+      Array [
+        "  relations",
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "b",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "i",
+                    ],
+                    Array [
+                      "n",
+                    ],
+                    Array [
+                      "g",
+                    ],
+                    Array [
+                      "_",
+                    ],
+                    Array [
+                      "m",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "n",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "g",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        null,
+                        Array [
+                          Array [
+                            "o",
+                          ],
+                          Array [
+                            "w",
+                          ],
+                          Array [
+                            "n",
+                          ],
+                          Array [
+                            "e",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                        ],
+                      ],
+                      Array [],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "m",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "m",
+                    ],
+                    Array [
+                      "b",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        null,
+                        Array [
+                          Array [
+                            "o",
+                          ],
+                          Array [
+                            "w",
+                          ],
+                          Array [
+                            "n",
+                          ],
+                          Array [
+                            "e",
+                          ],
+                          Array [
+                            "r",
+                          ],
+                        ],
+                      ],
+                      Array [],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "o",
+                  ],
+                  Array [
+                    "w",
+                  ],
+                  Array [
+                    "n",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "r",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "p",
+                  ],
+                  Array [
+                    "o",
+                  ],
+                  Array [
+                    "_",
+                  ],
+                  Array [
+                    "a",
+                  ],
+                  Array [
+                    "d",
+                  ],
+                  Array [
+                    "m",
+                  ],
+                  Array [
+                    "i",
+                  ],
+                  Array [
+                    "n",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "r",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "p",
+                  ],
+                  Array [
+                    "o",
+                  ],
+                  Array [
+                    "_",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "a",
+                  ],
+                  Array [
+                    "d",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "r",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "p",
+                  ],
+                  Array [
+                    "o",
+                  ],
+                  Array [
+                    "_",
+                  ],
+                  Array [
+                    "w",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                  Array [
+                    "i",
+                  ],
+                  Array [
+                    "t",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+    ],
+  ],
+  Array [
+    Array [
+      Array [],
+      Array [
+        "type",
+        Array [
+          Array [
+            " ",
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          null,
+          Array [
+            Array [
+              "a",
+            ],
+            Array [
+              "p",
+            ],
+            Array [
+              "p",
+            ],
+          ],
+        ],
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [],
+      Array [
+        "  relations",
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              Array [
+                "    define",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "p",
+                    ],
+                    Array [
+                      "p",
+                    ],
+                    Array [
+                      "_",
+                    ],
+                    Array [
+                      "m",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "n",
+                    ],
+                    Array [
+                      "a",
+                    ],
+                    Array [
+                      "g",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "r",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+              Array [
+                "as",
+                Array [
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+              Array [
+                Array [
+                  Array [
+                    null,
+                    Array [
+                      Array [
+                        "s",
+                      ],
+                      Array [
+                        "e",
+                      ],
+                      Array [
+                        "l",
+                      ],
+                      Array [
+                        "f",
+                      ],
+                    ],
+                  ],
+                  Array [
+                    " ",
+                  ],
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  "or",
+                  Array [
+                    Array [
+                      " ",
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "w",
+                            ],
+                            Array [
+                              "n",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      "from",
+                      Array [
+                        Array [
+                          " ",
+                        ],
+                      ],
+                      Array [
+                        Array [
+                          null,
+                          Array [
+                            Array [
+                              "o",
+                            ],
+                            Array [
+                              "w",
+                            ],
+                            Array [
+                              "n",
+                            ],
+                            Array [
+                              "e",
+                            ],
+                            Array [
+                              "r",
+                            ],
+                          ],
+                        ],
+                        Array [],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          Array [
+            Array [
+              Array [
+                Array [
+                  Array [],
+                ],
+                "
+",
+              ],
+            ],
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "o",
+                  ],
+                  Array [
+                    "w",
+                  ],
+                  Array [
+                    "n",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [],
+        ],
+      ],
+    ],
+  ],
+]
+`;
+
+exports[`DSL parseDSL() should correctly parse a simple sample 1`] = `
+Array [
+  Array [
+    Array [
+      Array [],
+      Array [
+        "type",
+        Array [
+          Array [
+            " ",
+          ],
+        ],
+      ],
+      Array [
+        Array [
+          null,
+          Array [
+            Array [
+              "g",
+            ],
+            Array [
+              "r",
+            ],
+            Array [
+              "o",
+            ],
+            Array [
+              "u",
+            ],
+            Array [
+              "p",
+            ],
+          ],
+        ],
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [],
+      Array [
+        "  relations",
+        Array [],
+      ],
+      Array [
+        Array [
+          Array [
+            Array [
+              Array [],
+            ],
+            "
+",
+          ],
+        ],
+      ],
+    ],
+    Array [
+      Array [
+        Array [
+          Array [],
+          Array [
+            Array [
+              "    define",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                null,
+                Array [
+                  Array [
+                    "w",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                  Array [
+                    "i",
+                  ],
+                  Array [
+                    "t",
+                  ],
+                  Array [
+                    "e",
+                  ],
+                  Array [
+                    "r",
+                  ],
+                ],
+              ],
+              Array [],
+            ],
+            Array [
+              Array [
+                " ",
+              ],
+            ],
+            Array [
+              "as",
+              Array [
+                Array [
+                  " ",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                Array [
+                  null,
+                  Array [
+                    Array [
+                      "s",
+                    ],
+                    Array [
+                      "e",
+                    ],
+                    Array [
+                      "l",
+                    ],
+                    Array [
+                      "f",
+                    ],
+                  ],
+                ],
+                Array [],
+              ],
+            ],
+          ],
+          Array [],
+        ],
+      ],
+    ],
+  ],
+]
+`;

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -1,0 +1,203 @@
+import { checkDSL } from "../src";
+import { parseDSL } from "../src/parse-dsl";
+
+describe("DSL", () => {
+  describe("parseDSL()", () => {
+    it("should throw if the code is incomplete", () => {
+      expect(() => {
+        parseDSL("type group");
+      }).toThrowError();
+    });
+
+    it("should correctly parse a simple sample", () => {
+      const result = parseDSL(`type group
+  relations
+    define writer as self`);
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it("should correctly parse a complex sample", () => {
+      const result = parseDSL(`type team
+  relations
+    define member as self
+
+type repo
+  relations
+    define admin as self or repo_admin from owner
+    define maintainer as self or admin
+    define owner as self
+    define reader as self or triager or repo_reader from owner
+    define triager as self or writer
+    define writer as self or maintainer or repo_writer from owner
+
+type org
+  relations
+    define billing_manager as self or owner
+    define member as self or owner
+    define owner as self
+    define repo_admin as self
+    define repo_reader as self
+    define repo_writer as self
+
+type app
+  relations
+    define app_manager as self or owner from owner
+    define owner as self`);
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe("checkDSL()", () => {
+    describe("invalid code", () => {
+      it("should handle `no relations`", () => {
+        const markers = checkDSL("type group");
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle `no definitions`", () => {
+        const markers = checkDSL(`type group
+  relations`);
+        expect(markers).toMatchSnapshot();
+      });
+    });
+
+    describe("invalid keywords", () => {
+      it("should handle invalid `self`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as se lf`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `as`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer a s self`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `define`", () => {
+        const markers = checkDSL(`type group
+  relations
+    dec lare writer as self`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `as`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer a s self`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `or`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define reader as self
+    define writer as self o r reader`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `and`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define reader as self
+    define writer as self an d reader`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `but not`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define reader as self
+    define writer as self but no t reader`);
+        expect(markers).toMatchSnapshot();
+      });
+    });
+
+    describe("semantics", () => {
+      it("should handle invalid `self-error`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as writer`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `relation not define`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as reader`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `self-ref in but not`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as self but not writer`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `invalid but not`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as self but not reader`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `invalid from`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as self or reader from test`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `invalid or`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as self or reader`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle invalid `invalid and`", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as self and reader`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should handle duplicated definition", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as self
+    define writer as self`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should be able to handle more than one error", () => {
+        const markers = checkDSL(`type group
+  relations
+    define writer as writer
+    define hi as self
+    define relation as relation2 from relation2
+    define domain as domain from domain but not domain`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should allow self reference", () => {
+        const markers = checkDSL(`type group
+  relations
+    define member as self or member from member`);
+        expect(markers).toMatchSnapshot();
+      });
+
+      it("should not allow impossible self reference", () => {
+        const markers = checkDSL(`type group
+  relations
+    define member as member from member`);
+        expect(markers).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
These reporters can be used to report errors in the syntax.

They are currently in use as the building block for validation in the [Auth0 FGA Playground](https://play.fga.dev).