### PR TITLE
fix(check-dsl): incorrect parsing of relations starting with `as`

### DIFF
--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -29,7 +29,7 @@ export const checkDSL = (codeInEditor: string) => {
       const relations = [Keywords.SELF as string];
 
       _.forEach(r[2], (r2, idx: number) => {
-        const relation = _.trim(_.flattenDeep(r2).join("")).match(/define\s+(.*)\s+as/)?.[1];
+        const relation = _.trim(_.flattenDeep(r2).join("")).match(/define\s+(.*)\s+as\s/)?.[1];
         if (!relation) {
           return;
         }

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -126,6 +126,8 @@ Array [
 ]
 `;
 
+exports[`DSL checkDSL() semantics should allow model with relations starting with as 1`] = `Array []`;
+
 exports[`DSL checkDSL() semantics should allow self reference 1`] = `Array []`;
 
 exports[`DSL checkDSL() semantics should be able to handle more than one error 1`] = `

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -181,5 +181,63 @@ type organization
   relations
     define member as self
 `
-  }
+  },
+  {
+    "name": "relations-starting-with-as",
+    "json": {
+      "type_definitions": [
+        { "type": "org", "relations": { "member": { "this": {} } } },
+        {
+          "type": "feature",
+          "relations": {
+            "associated_plan": { "this": {} },
+            "access": {
+              "tupleToUserset": {
+                "tupleset": { "object": "", "relation": "associated_plan" },
+                "computedUserset": { "object": "", "relation": "subscriber_member" }
+              }
+            }
+          }
+        }, {
+          "type": "plan",
+          "relations": {
+            "subscriber": { "this": {} },
+            "subscriber_member": {
+              "tupleToUserset": {
+                "tupleset": { "object": "", "relation": "subscriber" },
+                "computedUserset": { "object": "", "relation": "member" }
+              }
+            }
+          }
+        }, {
+          "type": "permission",
+          "relations": {
+            "access_feature": {
+              "tupleToUserset": {
+                "tupleset": {
+                  "object": "",
+                  "relation": "associated_feature"
+                }, "computedUserset": { "object": "", "relation": "access" }
+              }
+            }, "associated_feature": { "this": {} }
+          }
+        }]
+    },
+    "friendly": `type org
+  relations
+    define member as self
+type feature
+  relations
+    define associated_plan as self
+    define access as subscriber_member from associated_plan
+type plan
+  relations
+    define subscriber as self
+    define subscriber_member as member from subscriber
+type permission
+  relations
+    define access_feature as access from associated_feature
+    define associated_feature as self
+`
+  },
 ];

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -198,6 +198,25 @@ type app
     define member as member from member`);
         expect(markers).toMatchSnapshot();
       });
+
+      it("should allow model with relations starting with as", () => {
+        const markers = checkDSL(`type org
+  relations
+    define member as self
+type feature
+  relations
+    define associated_plan as self
+    define access as subscriber_member from associated_plan
+type plan
+  relations
+    define subscriber as self
+    define subscriber_member as member from subscriber
+type permission
+  relations
+    define access_feature as access from associated_feature
+    define associated_feature as self`);
+        expect(markers).toMatchSnapshot();
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

We were incorrectly detecting relations that start with `as` as the end boundary of relations instead of the keyword `as`. Leading to the relation in certain cases to be improperly detected.

E.g. when the definition is: `define access as subscriber from associated_plan`, the detected relation by the reporter was `access as subscriber from`.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Resolves https://github.com/openfga/syntax-transformer/issues/35

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
