### PR TITLE
support "type x" with no relations

### DIFF
--- a/src/api-to-friendly.ts
+++ b/src/api-to-friendly.ts
@@ -84,8 +84,6 @@ const apiToFriendlyType = (typeDef: TypeDefinition | TypeDefinition["relations"]
         const relationDefinition = (typeDef as TypeDefinition).relations[relation];
         apiToFriendlyRelation(relation, relationDefinition, relations, idx, newSyntax);
       });
-    } else {
-      newSyntax.push(`  ${Keywords.RELATIONS} ${Keywords.RELATIONS_NONE}`);
     }
   } else {
     // A subset of the type definition with only the relations object was passed

--- a/src/friendly-to-api.ts
+++ b/src/friendly-to-api.ts
@@ -57,99 +57,98 @@ const filterBlanksAndTrim = (list: string[]) => list.filter((entry) => entry).ma
 
 export const friendlySyntaxToApiSyntax = (config: string): TypeDefinitions => {
   const typeDefinitions: TypeDefinitions = { type_definitions: [] };
-  const result: string[][][][] = parseDSL(config);
+  const allTypeDefinitions: string[][][][] = parseDSL(config);
 
-  result.forEach((r) => {
-    const typeDef: TypeDefinition = { type: flattenDeep(r[0][2]).join(""), relations: {} };
-    const definitions = flatten(r[2]);
+  allTypeDefinitions.forEach((typeDefinition) => {
+    // typeDefinition[0] contains the first line "type xxx"
+    const nameOfType = flattenDeep(typeDefinition[0][2]).join("");
+    const typeDef: TypeDefinition = { type: nameOfType, relations: {} };
 
-    definitions.forEach((def) => {
-      const flattened: any = flatten(def);
-      const definition = flattenDeep(flatten(flattened[1] as [])
-        .filter((r: any) => flattenDeep(r).join("").trim().length)[1]).join("");
-      const relations: any[] = [];
-      let rawRelations: any[] = [];
+    // typeDefinition[1] contains "relations \n define yyy as zzz"
+    if (typeDefinition[1].length == 1) {
+      const relationDefinitions: any[] = flatten(typeDefinition[1][0][1]);
+      relationDefinitions.forEach((relationDefinition) => {
+        const flattenedRelationDefinition: any = flatten(relationDefinition);
+        const nameOfRelation = flattenedRelationDefinition[1][0][1].join("")
+        const relations: any[] = [];
+        let rawRelations: any[] = [...flatten(flattenedRelationDefinition[4])];
 
-      if (!!flattened[1]) { // at least one relation defined
-        rawRelations = [...flatten(flattened[1][4])];
-
-        if (flattened[1].length === 2) {
-          flattened[1][0][4] = flattened[1][0][4].concat(flatMapDeep(flattened[1][1]).join(""));
-          rawRelations = flattened[1][0][4];
+        // if (flattenedRelationDefinition[1].length === 2) {
+        //   flattenedRelationDefinition[1][0][4] = flattenedRelationDefinition[1][0][4].concat(flatMapDeep(flattenedRelationDefinition[1][1]).join(""));
+        //   rawRelations = flattenedRelationDefinition[1][0][4];
+        // }
+        for (const rawRelation of rawRelations) {
+          const flat = flattenDeep(rawRelation);
+          const value = flat.join("");
+  
+          if (isEmpty(flat)) {
+            break;
+          }
+  
+          if (typeof value === "string") {
+            relations.push(value);
+          } else {
+            relations.push(...(value as any));
+          }
         }
-      }    
-
-      for (const rawRelation of rawRelations) {
-        const flat = flattenDeep(rawRelation);
-        const value = flat.join("");
-
-        if (isEmpty(flat)) {
-          break;
-        }
-
-        if (typeof value === "string") {
-          relations.push(value);
+  
+        if (relations.length === 1) {
+          typeDef.relations[nameOfRelation] = resolveRelation(relations[0]);
         } else {
-          relations.push(...(value as any));
-        }
-      }
-
-      if (relations.length === 1) {
-        typeDef.relations[definition] = resolveRelation(relations[0]);
-      } else {
-        const isOr = flattenDeep(relations).join("").includes(` ${Keywords.OR} `);
-        const isAnd = flattenDeep(relations).join("").includes(` ${Keywords.AND} `);
-        const isButNot = flattenDeep(relations).join("").includes(` ${Keywords.BUT_NOT} `);
-        const isFrom = flattenDeep(relations).join("").includes(` ${Keywords.FROM} `);
-
-        if (isFrom) {
-          typeDef.relations[definition] = resolveRelation(flattenDeep(relations).join(""));
-        }
-
-        if (isOr) {
-          const child: Userset[] = [];
-          const list = [relations[0], ...relations[1].replace("or ", "").split(/\sor\s/)];
-
-          filterKeywords(filterBlanksAndTrim(list)).forEach((relation) => {
-            child.push(resolveRelation(relation));
-          });
-
-          typeDef.relations[definition] = {
-            union: {
-              child,
-            },
-          };
-        }
-
-        if (isAnd) {
-          const child: Userset[] = [];
-          const list = [relations[0], ...relations[1].replace("and ", "").split(/\sand\s/)];
-
-          filterKeywords(filterBlanksAndTrim(list)).forEach((relation) => {
-            child.push(resolveRelation(relation));
-          });
-
-          typeDef.relations[definition] = {
-            intersection: {
-              child,
-            },
-          };
-        }
-
-        if (isButNot) {
-          typeDef.relations[definition] = {
-            difference: {
-              base: {
-                ...resolveRelation(relations[0].trim()),
+          const isOr = flattenDeep(relations).join("").includes(` ${Keywords.OR} `);
+          const isAnd = flattenDeep(relations).join("").includes(` ${Keywords.AND} `);
+          const isButNot = flattenDeep(relations).join("").includes(` ${Keywords.BUT_NOT} `);
+          const isFrom = flattenDeep(relations).join("").includes(` ${Keywords.FROM} `);
+  
+          if (isFrom) {
+            typeDef.relations[nameOfRelation] = resolveRelation(flattenDeep(relations).join(""));
+          }
+  
+          if (isOr) {
+            const child: Userset[] = [];
+            const list = [relations[0], ...relations[1].replace("or ", "").split(/\sor\s/)];
+  
+            filterKeywords(filterBlanksAndTrim(list)).forEach((relation) => {
+              child.push(resolveRelation(relation));
+            });
+  
+            typeDef.relations[nameOfRelation] = {
+              union: {
+                child,
               },
-              subtract: {
-                ...resolveRelation(relations[1].split("but not ")[1].trim()),
+            };
+          }
+  
+          if (isAnd) {
+            const child: Userset[] = [];
+            const list = [relations[0], ...relations[1].replace("and ", "").split(/\sand\s/)];
+  
+            filterKeywords(filterBlanksAndTrim(list)).forEach((relation) => {
+              child.push(resolveRelation(relation));
+            });
+  
+            typeDef.relations[nameOfRelation] = {
+              intersection: {
+                child,
               },
-            },
-          };
+            };
+          }
+  
+          if (isButNot) {
+            typeDef.relations[nameOfRelation] = {
+              difference: {
+                base: {
+                  ...resolveRelation(relations[0].trim()),
+                },
+                subtract: {
+                  ...resolveRelation(relations[1].split("but not ")[1].trim()),
+                },
+              },
+            };
+          }
         }
-      }
-    });
+      });
+    }
 
     typeDefinitions.type_definitions!.push(typeDef);
   });

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -24,10 +24,10 @@ function compileGrammar(sourceCode: string): Grammar {
 }
 
 export const grammar: Grammar = compileGrammar(`
-types           -> (_newline):* (type relations (_no_relations | (define_or | define_and | define_but_not | define_base):*)):* 
+types           -> (_newline):* (type (relations (define_or | define_and | define_but_not | define_base):*):*):*
 
 type            -> (_comment):* _type _naming (_newline):+
-relations       -> (_comment):* _relations
+relations       -> (_comment):* _relations (_newline):+
 define_or       -> (_comment):* (define_raw (_or):+) (_newline):*
 define_and      -> (_comment):* (define_raw (_and):+) (_newline):*
 define_but_not  -> (_comment):* (define_raw (_but_not):+) (_newline):*
@@ -40,8 +40,8 @@ _and            -> "and" _spacing (_naming | _from)
 _but_not        -> "but not" _spacing (_naming | _from)
 _from           -> _naming _spacing "from" _spacing _naming
 
-_define         -> (_newline):+ "    define" _spacing
-_relations      -> "  relations" _optional_space
+_define         -> "    define" _spacing
+_relations      -> "  relations" " ":*
 _type           -> "type" _spacing
 _no_relations   -> "none" (_newline):*
 _naming         -> (("$"):? ( [a-z] | [A-Z] | [0-9] |  "_" |  "-" ):+) " ":*

--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -1,7 +1,6 @@
 export enum Keywords {
   NAMESPACE = "type",
   RELATIONS = "relations",
-  RELATIONS_NONE = "none",
   SELF = "self",
   DEFINE = "define",
   AS = "as",

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -11,7 +11,7 @@ export const testModels: { name: string, json: TypeDefinitions, friendly: string
         }
       ]
     },
-    "friendly": "type document\n  relations none\n"
+    "friendly": "type document\n"
   },
   {
     "name": "one type with no relations and another with one relation",
@@ -34,7 +34,7 @@ export const testModels: { name: string, json: TypeDefinitions, friendly: string
         }
       ]
     },
-    "friendly": "type group\n  relations none\ntype document\n  relations\n    define viewer as self\n    define editor as self\n"
+    "friendly": "type group\ntype document\n  relations\n    define viewer as self\n    define editor as self\n"
   },
   {
     "name": "simple model",

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -10,8 +10,7 @@ describe("DSL", () => {
     });
 
     it("should correctly parse a type with no relations", () => {
-      const result = parseDSL(`type group
-  relations none`);
+      const result = parseDSL(`type group`);
 
       expect(result).toMatchSnapshot();
     });
@@ -196,13 +195,6 @@ type app
         const markers = checkDSL(`type group
   relations
     define member as self or member from member`);
-        expect(markers).toMatchSnapshot();
-      });
-
-      it("should not allow relations none and a relation defined", () => {
-        const markers = checkDSL(`type group
-  relations none
-    define member as self`);
         expect(markers).toMatchSnapshot();
       });
 


### PR DESCRIPTION
Support types with no relations, for example:

```
type car

type truck 
   relations
      ...
```

## References
- Previous similar work but with syntax `relations none`: https://github.com/openfga/syntax-transformer/pull/47

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
