### PR TITLE
fix: correct column identified in self-ref error

### DIFF
--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -87,7 +87,7 @@ export const checkDSL = (codeInEditor: string) => {
               reporter.invalidFrom({
                 lineIndex,
                 value: target.target,
-                clause: target.target,
+                clause: Keywords.FROM,
               });
             }
           }

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -68,6 +68,12 @@ export const reportUseSelf = ({ markers, lines, lineIndex, value }: ReporterOpts
     value,
     relatedInformation: { type: "self-error" },
     lineIndex,
+    customResolver: (wordIdx, rawLine, value) => {
+      const fromStartsAt = wordIdx;
+      wordIdx = fromStartsAt + value.length + rawLine.slice(fromStartsAt + value.length).search(value) + 1;
+
+      return wordIdx;
+    },
   });
 };
 
@@ -80,7 +86,7 @@ export const reportInvalidFrom = ({ markers, lines, lineIndex, value, clause }: 
     lineIndex,
     customResolver: (wordIdx, rawLine, value) => {
       const fromStartsAt = rawLine.indexOf(clause);
-      wordIdx = fromStartsAt + rawLine.slice(fromStartsAt, fromStartsAt + clause.length).lastIndexOf(value) + 1;
+      wordIdx = fromStartsAt + clause.length + rawLine.slice(fromStartsAt + clause.length).search(value) + 1;
 
       return wordIdx;
     },

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -111,7 +111,7 @@ exports[`DSL checkDSL() semantics should allow self reference 1`] = `[]`;
 exports[`DSL checkDSL() semantics should be able to handle more than one error 1`] = `
 [
   {
-    "endColumn": 18,
+    "endColumn": 28,
     "endLineNumber": 3,
     "message": "For auto-referencing use 'self'.",
     "relatedInformation": {
@@ -119,7 +119,7 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     },
     "severity": 8,
     "source": "linter",
-    "startColumn": 12,
+    "startColumn": 22,
     "startLineNumber": 3,
   },
   {
@@ -148,7 +148,7 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     "startLineNumber": 5,
   },
   {
-    "endColumn": 18,
+    "endColumn": 28,
     "endLineNumber": 6,
     "message": "For auto-referencing use 'self'.",
     "relatedInformation": {
@@ -156,7 +156,7 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     },
     "severity": 8,
     "source": "linter",
-    "startColumn": 12,
+    "startColumn": 22,
     "startLineNumber": 6,
   },
 ]
@@ -316,7 +316,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`relation not define\` 
 exports[`DSL checkDSL() semantics should handle invalid \`self-error\` 1`] = `
 [
   {
-    "endColumn": 18,
+    "endColumn": 28,
     "endLineNumber": 3,
     "message": "For auto-referencing use 'self'.",
     "relatedInformation": {
@@ -324,7 +324,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`self-error\` 1`] = `
     },
     "severity": 8,
     "source": "linter",
-    "startColumn": 12,
+    "startColumn": 22,
     "startLineNumber": 3,
   },
 ]
@@ -333,7 +333,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`self-error\` 1`] = `
 exports[`DSL checkDSL() semantics should handle invalid \`self-ref in but not\` 1`] = `
 [
   {
-    "endColumn": 18,
+    "endColumn": 41,
     "endLineNumber": 3,
     "message": "For auto-referencing use 'self'.",
     "relatedInformation": {
@@ -341,7 +341,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`self-ref in but not\` 
     },
     "severity": 8,
     "source": "linter",
-    "startColumn": 12,
+    "startColumn": 35,
     "startLineNumber": 3,
   },
 ]
@@ -368,7 +368,7 @@ exports[`DSL checkDSL() semantics should identify correct error line number if t
 exports[`DSL checkDSL() semantics should not allow impossible self reference 1`] = `
 [
   {
-    "endColumn": 18,
+    "endColumn": 40,
     "endLineNumber": 3,
     "message": "Cannot self-reference (\`member\`) within \`from\` clause.",
     "relatedInformation": {
@@ -376,7 +376,7 @@ exports[`DSL checkDSL() semantics should not allow impossible self reference 1`]
     },
     "severity": 8,
     "source": "linter",
-    "startColumn": 12,
+    "startColumn": 34,
     "startLineNumber": 3,
   },
 ]


### PR DESCRIPTION

## Description
Correct column identified in self-ref error

<img width="2012" alt="Screen Shot 2022-09-29 at 5 21 15 PM" src="https://user-images.githubusercontent.com/10730463/193144619-ddc96d0e-4d93-4438-8f8b-307bfd9c1ca1.png">

## References
Close https://github.com/openfga/syntax-transformer/issues/62


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
