### PR TITLE
fix: handle case if relations not defined in full model

### DIFF
--- a/src/api-to-friendly.ts
+++ b/src/api-to-friendly.ts
@@ -72,10 +72,10 @@ const apiToFriendlyRelation = (
 };
 
 const apiToFriendlyType = (typeDef: TypeDefinition | TypeDefinition["relations"], newSyntax: string[]) => {
-  if (typeDef?.relations) {
+  if (typeDef?.type) {
     // A full type definition was passed
     newSyntax.push(`${Keywords.NAMESPACE} ${typeDef.type}`);
-    if (Object.keys(typeDef.relations).length) {
+    if (typeDef?.relations && Object.keys(typeDef?.relations).length) {
       newSyntax.push(`  ${Keywords.RELATIONS}`);
 
       const relations = Object.keys(typeDef.relations);

--- a/tests/api-to-friendly.test.ts
+++ b/tests/api-to-friendly.test.ts
@@ -4,10 +4,16 @@ import { apiSyntaxToFriendlySyntax } from "../src";
 import { testModels } from "./data";
 
 describe("api-to-friendly", () => {
-  testModels.forEach(testCase => {
+  testModels.forEach((testCase) => {
     it(`should transform ${testCase.name}`, () => {
       const friendlySyntax = apiSyntaxToFriendlySyntax(testCase.json);
       expect(friendlySyntax).toEqual(testCase.friendly);
     });
+  });
+
+  it("Having no relations should still yield correct DSL", () => {
+    const friendlySyntax = apiSyntaxToFriendlySyntax({ type_definitions: [{ type: "user" }] });
+    const expectedOutput = "type user\n";
+    expect(friendlySyntax).toEqual(expectedOutput);
   });
 });


### PR DESCRIPTION
## Description
Identify partial model as type is not set instead of using relations.


## References
Close https://github.com/openfga/syntax-transformer/issues/65

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
