### PR TITLE
feat: allow types for relations

### DIFF
--- a/src/api-to-friendly.ts
+++ b/src/api-to-friendly.ts
@@ -30,14 +30,14 @@ const apiToFriendlyRelation = (
   const relationKeys = Object.keys(relationDefinition);
   const relationMetadata = (metadata as Metadata)?.relations?.[relation];
   
-  let allowedTypesArray = relationMetadata?.directly_related_user_types?.map((relationReference) => {
+  const allowedTypesArray = relationMetadata?.directly_related_user_types?.map((relationReference) => {
     if (relationReference.relation) {
       return `${relationReference.type}#${relationReference.relation}`;
     }
     return relationReference.type;
   }) || [];
   
-  let allowedTypes = allowedTypesArray.length > 0 ? `: [${allowedTypesArray.join(",")}]` : "";
+  const allowedTypes = allowedTypesArray.length ? `: [${allowedTypesArray.join(",")}]` : "";
 
   const define = [`    ${Keywords.DEFINE} ${relation}${allowedTypes}${relationKeys?.length ? ` ${Keywords.AS} ` : ""}`];
 
@@ -105,7 +105,7 @@ const apiToFriendlyType = (typeDef: TypeDefinition | TypeDefinition["relations"]
     }
     const relation = relations[0];
     const userSet = (typeDef as any)[relation];
-    apiToFriendlyRelation(relation, userSet, relations, 0, typeDef?.metadata, newSyntax);
+    apiToFriendlyRelation(relation, userSet, relations, 0, undefined, newSyntax);
   }
 };
 

--- a/src/api-to-friendly.ts
+++ b/src/api-to-friendly.ts
@@ -29,8 +29,7 @@ const apiToFriendlyRelation = (
 ) => {
   const relationKeys = Object.keys(relationDefinition);
   const relationMetadata = (metadata as Metadata)?.relations?.[relation];
-
-  let allowedTypes = "";
+  
   let allowedTypesArray = relationMetadata?.directly_related_user_types?.map((relationReference) => {
     if (relationReference.relation) {
       return `${relationReference.type}#${relationReference.relation}`;
@@ -38,10 +37,8 @@ const apiToFriendlyRelation = (
     return relationReference.type;
   }) || [];
   
-  if (allowedTypesArray.length > 0) {
-    // e.g. : [user,team#member]
-    allowedTypes = `: [${allowedTypesArray.join(",")}]`;
-  }
+  let allowedTypes = allowedTypesArray.length > 0 ? `: [${allowedTypesArray.join(",")}]` : "";
+
   const define = [`    ${Keywords.DEFINE} ${relation}${allowedTypes}${relationKeys?.length ? ` ${Keywords.AS} ` : ""}`];
 
   // Read simple definitions

--- a/src/api-to-friendly.ts
+++ b/src/api-to-friendly.ts
@@ -1,4 +1,4 @@
-import { TypeDefinition, WriteAuthorizationModelRequest, Userset } from "@openfga/sdk";
+import { TypeDefinition, WriteAuthorizationModelRequest, Userset, Metadata } from "@openfga/sdk";
 import { Keywords } from "./keywords";
 
 const readFrom = (obj: Userset, define: string[]) => {
@@ -24,10 +24,25 @@ const apiToFriendlyRelation = (
   relationDefinition: Userset,
   relations: string[],
   idx: number,
+  metadata: Userset | Metadata | undefined,
   newSyntax: string[],
 ) => {
   const relationKeys = Object.keys(relationDefinition);
-  const define = [`    ${Keywords.DEFINE} ${relation}${relationKeys?.length ? ` ${Keywords.AS} ` : ""}`];
+  const relationMetadata = (metadata as Metadata)?.relations?.[relation];
+
+  let allowedTypes = "";
+  let allowedTypesArray = relationMetadata?.directly_related_user_types?.map((relationReference) => {
+    if (relationReference.relation) {
+      return `${relationReference.type}#${relationReference.relation}`;
+    }
+    return relationReference.type;
+  }) || [];
+  
+  if (allowedTypesArray.length > 0) {
+    // e.g. : [user,team#member]
+    allowedTypes = `: [${allowedTypesArray.join(",")}]`;
+  }
+  const define = [`    ${Keywords.DEFINE} ${relation}${allowedTypes}${relationKeys?.length ? ` ${Keywords.AS} ` : ""}`];
 
   // Read simple definitions
   readFrom(relationDefinition, define);
@@ -82,7 +97,7 @@ const apiToFriendlyType = (typeDef: TypeDefinition | TypeDefinition["relations"]
 
       relations.forEach((relation: any, idx: number) => {
         const relationDefinition = (typeDef.relations as any)[relation];
-        apiToFriendlyRelation(relation, relationDefinition, relations, idx, newSyntax);
+        apiToFriendlyRelation(relation, relationDefinition, relations, idx, typeDef.metadata, newSyntax);
       });
     }
   } else {
@@ -93,7 +108,7 @@ const apiToFriendlyType = (typeDef: TypeDefinition | TypeDefinition["relations"]
     }
     const relation = relations[0];
     const userSet = (typeDef as any)[relation];
-    apiToFriendlyRelation(relation, userSet, relations, 0, newSyntax);
+    apiToFriendlyRelation(relation, userSet, relations, 0, typeDef?.metadata, newSyntax);
   }
 };
 

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -38,7 +38,7 @@ export const checkDSL = (codeInEditor: string) => {
     const globalRelations: Record<string, boolean> = { [Keywords.SELF]: true };
 
     // Looking at the types
-    parserResults.forEach((typeDef) => {
+    parserResults.types.forEach((typeDef) => {
       const typeName = typeDef.type;
 
       // Include keyword
@@ -62,7 +62,7 @@ export const checkDSL = (codeInEditor: string) => {
       relationsPerType[typeName] = encounteredRelationsInType;
     });
 
-    parserResults.forEach((typeDef) => {
+    parserResults.types.forEach((typeDef) => {
       const typeName = typeDef.type;
 
       // parse through each of the relations to do validation

--- a/src/friendly-to-api.ts
+++ b/src/friendly-to-api.ts
@@ -2,6 +2,7 @@ import { AuthorizationModel, Userset } from "@openfga/sdk";
 
 import {
   parseDSL,
+  ParserResult,
   RelationDefOperator,
   RelationTargetParserResult,
   RewriteType,
@@ -38,10 +39,10 @@ const resolveRelation = (relation: RelationTargetParserResult): Userset => {
   }
 };
 
-export const friendlySyntaxToApiSyntax = (config: string): Required<Pick<AuthorizationModel, "type_definitions">> => {
-  const result: TypeDefParserResult[] = parseDSL(config);
+export const friendlySyntaxToApiSyntax = (config: string): Required<Pick<AuthorizationModel, "type_definitions" | "schema_version">> => {
+  const result: ParserResult = parseDSL(config);
 
-  const typeDefinitions = result.map(({ type: typeName, relations: rawRelations }) => {
+  const typeDefinitions = result.types.map(({ type: typeName, relations: rawRelations }) => {
     const relationsMap: Record<string, Userset> = {};
     const relationsMetadataMap: Record<string, any> = {}
     let metadataAvailable = false;
@@ -104,5 +105,5 @@ export const friendlySyntaxToApiSyntax = (config: string): Required<Pick<Authori
     return { type: typeName, relations: relationsMap };
   });
 
-  return { type_definitions: typeDefinitions };
+  return { type_definitions: typeDefinitions, schema_version: result.schemaVersion };
 };

--- a/src/friendly-to-api.ts
+++ b/src/friendly-to-api.ts
@@ -85,12 +85,12 @@ export const friendlySyntaxToApiSyntax = (config: string): Required<Pick<Authori
 
       allowedTypes?.forEach((allowedType: string) => {
         metadataAvailable = true;
-          let objectAndRelation = allowedType.split("#");
+          const [userType, usersetRelation] = allowedType.split("#");
           let toAdd: any = {
-            "type": objectAndRelation[0]
+            "type": userType
           };
-          if (objectAndRelation.length == 2) {
-            toAdd["relation"] = objectAndRelation[1];
+          if (usersetRelation) {
+            toAdd["relation"] = usersetRelation;
           }
           relationsMetadataMap[relationName]["directly_related_user_types"].push(toAdd);
       })

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -1,25 +1,21 @@
 @preprocessor typescript
 
 types           -> (_newline):* (type (relations (define):+):*):* {%
-    data => {
-         // @ts-ignore
-		const types = data[1].map((datum : any) => {
-		    const relations = datum[1][0] ? datum[1][0][1].flat() : [];
-		    return { ...datum[0], relations }
-		})
-		let schemaVersion = "1.0"
+    // @ts-ignore
+    (data) => {
         // @ts-ignore
-		types.forEach(type => {
-             // @ts-ignore
-			type.relations.forEach(relation => {
-				if (relation.allowedTypes.length > 0) {
-					schemaVersion = "1.1"
-				}
-			})
-		})
-		return {types: types, schemaVersion: schemaVersion}
-	}	
-	
+        const types = data[1].map((datum) => {
+            const relations = datum[1][0] ? datum[1][0][1].flat() : [];
+
+            return { ...datum[0], relations }
+        })
+
+        // @ts-ignore
+        const hasTypes = types.some(type => type.relations.some(relation => relation.allowedTypes.length));
+        const schemaVersion = hasTypes ? "1.1" : "1.0";
+
+        return {types: types, schemaVersion: schemaVersion}
+    }
 %}
 
 type            -> _multiline_comment _type _naming (_newline):+ {%
@@ -43,7 +39,7 @@ define          -> (_newline):+ _multiline_comment define_initial (_relation_typ
                 type: 'single',
                 targets: [def]
             }
-		const allowedTypes = data[3] ? data[3][0] : []
+        const allowedTypes = data[3] ? data[3][0] : []
 
         return { comment: data[1], allowedTypes, relation, definition };
     }

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -1,11 +1,25 @@
 @preprocessor typescript
 
 types           -> (_newline):* (type (relations (define):+):*):* {%
-    // @ts-ignore
-    data => data[1].map((datum) => {
+    data => {
+         // @ts-ignore
+		const types = data[1].map((datum : any) => {
 		    const relations = datum[1][0] ? datum[1][0][1].flat() : [];
 		    return { ...datum[0], relations }
 		})
+		let schemaVersion = "1.0"
+        // @ts-ignore
+		types.forEach(type => {
+             // @ts-ignore
+			type.relations.forEach(relation => {
+				if (relation.allowedTypes.length > 0) {
+					schemaVersion = "1.1"
+				}
+			})
+		})
+		return {types: types, schemaVersion: schemaVersion}
+	}	
+	
 %}
 
 type            -> _multiline_comment _type _naming (_newline):+ {%
@@ -29,7 +43,7 @@ define          -> (_newline):+ _multiline_comment define_initial (_relation_typ
                 type: 'single',
                 targets: [def]
             }
-        const allowedTypes = data[3] ? data[3][0] : []
+		const allowedTypes = data[3] ? data[3][0] : []
 
         return { comment: data[1], allowedTypes, relation, definition };
     }
@@ -88,7 +102,7 @@ _relation_types -> ":" _optional_space "[" _array_of_types "]" _spacing {%
     data => data[3]
 %}
 
-_array_of_types -> ("$"):? ([a-zA-Z0-9_#\-,\s]):* {%
+_array_of_types -> ("$"):? ([a-zA-Z0-9_#\-,\s]):+ {%
     data => data.flat(3).join('').split(",").map(i => i.trim())
 %}
 

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -88,8 +88,7 @@ _relation_types -> ":" _optional_space "[" _array_of_types "]" _spacing {%
     data => data[3]
 %}
 
-
-_array_of_types -> ([a-zA-Z0-9_#,\s]):* {%
+_array_of_types -> ("$"):? ([a-zA-Z0-9_#\-,\s]):* {%
     data => data.flat(3).join('').split(",").map(i => i.trim())
 %}
 

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -14,7 +14,7 @@ type            -> _multiline_comment _type _naming (_newline):+ {%
 relations       -> _multiline_comment _relations {%
     data => data[1]
 %}
-define          -> (_newline):+ _multiline_comment define_initial _as (define_base | define_or | define_and | define_but_not) (_newline):* {%
+define          -> (_newline):+ _multiline_comment define_initial (_relation_types):? _as (define_base | define_or | define_and | define_but_not) (_newline):* {%
     (data, _location, reject) => {
         const relation = data[2];
 
@@ -23,18 +23,19 @@ define          -> (_newline):+ _multiline_comment define_initial _as (define_ba
             return reject;
         }
 
-        const def = data[4][0];
+        const def = data[5][0];
         const definition = def.type ? def :
             {
                 type: 'single',
                 targets: [def]
             }
+        const allowedTypes = data[3] ? data[3][0] : []
 
-        return { comment: data[1], relation, definition };
+        return { comment: data[1], allowedTypes, relation, definition };
     }
 %}
 
-define_initial      -> _define _naming _spacing {%
+define_initial      -> _define _naming {%
 	data => data[1]
 %}
 
@@ -81,6 +82,15 @@ _comment        -> " ":* "#" _spacing _naming (_spacing _word):*  _newline {%
 %}
 _word           -> ([a-z] | [A-Z] | [0-9] |  "_" |  "-" | "," | "&" | "+" | "/" | "$" ):+ _optional_space {%
     data => data.flat(3).join('').trim()
+%}
+
+_relation_types -> ":" _optional_space "[" _array_of_types "]" _spacing {%
+    data => data[3]
+%}
+
+
+_array_of_types -> ([a-zA-Z0-9_#,\s]):* {%
+    data => data.flat(3).join('').split(",").map(i => i.trim())
 %}
 
 _from           -> "from"

--- a/src/parse-dsl.ts
+++ b/src/parse-dsl.ts
@@ -39,7 +39,12 @@ export interface TypeDefParserResult {
   relations: RelationDefParserResult<RelationDefOperator>[];
 }
 
-export const parseDSL = (code: string): TypeDefParserResult[] => {
+export interface ParserResult {
+  schemaVersion: string;
+  types: TypeDefParserResult[];
+}
+
+export const parseDSL = (code: string): ParserResult => {
   const parser = new Parser(Grammar.fromCompiled(grammar));
   parser.feed(code.trim() + "\n");
   return parser.results[0] || [];

--- a/src/parse-dsl.ts
+++ b/src/parse-dsl.ts
@@ -24,6 +24,7 @@ export interface RelationTargetParserResult {
 export interface RelationDefParserResult<T extends RelationDefOperator> {
   comment: string;
   relation: string;
+  allowedTypes: string[];
   definition: {
     type: T;
     targets: T extends RelationDefOperator.Exclusion ? undefined : RelationTargetParserResult[];

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DSL checkDSL() invalid code should handle \`no definitions\` 1`] = `[]`;
+exports[`DSL checkDSL() invalid code should handle \`no definitions\` 1`] = `
+[
+  {
+    "endColumn": 9007199254740991,
+    "endLineNumber": 2,
+    "message": "Invalid syntax",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 0,
+    "startLineNumber": 0,
+  },
+]
+`;
 
 exports[`DSL checkDSL() invalid code should handle \`no relations\` 1`] = `[]`;
 
@@ -385,341 +397,350 @@ exports[`DSL checkDSL() semantics should not allow impossible self reference 1`]
 exports[`DSL checkDSL() should correctly parse a simple sample 1`] = `[]`;
 
 exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
-[
-  {
-    "comment": "",
-    "relations": [
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+{
+  "schemaVersion": "1.0",
+  "types": [
+    {
+      "comment": "",
+      "relations": [
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "member",
         },
-        "relation": "member",
-      },
-    ],
-    "type": "team",
-  },
-  {
-    "comment": "",
-    "relations": [
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": "owner",
-              "rewrite": "tuple_to_userset",
-              "target": "repo_admin",
-            },
-          ],
-          "type": "union",
+      ],
+      "type": "team",
+    },
+    {
+      "comment": "",
+      "relations": [
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": "owner",
+                "rewrite": "tuple_to_userset",
+                "target": "repo_admin",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "admin",
         },
-        "relation": "admin",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": undefined,
-              "rewrite": "computed_userset",
-              "target": "admin",
-            },
-          ],
-          "type": "union",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": undefined,
+                "rewrite": "computed_userset",
+                "target": "admin",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "maintainer",
         },
-        "relation": "maintainer",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "owner",
         },
-        "relation": "owner",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": undefined,
-              "rewrite": "computed_userset",
-              "target": "triager",
-            },
-            {
-              "from": "owner",
-              "rewrite": "tuple_to_userset",
-              "target": "repo_reader",
-            },
-          ],
-          "type": "union",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": undefined,
+                "rewrite": "computed_userset",
+                "target": "triager",
+              },
+              {
+                "from": "owner",
+                "rewrite": "tuple_to_userset",
+                "target": "repo_reader",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "reader",
         },
-        "relation": "reader",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": undefined,
-              "rewrite": "computed_userset",
-              "target": "writer",
-            },
-          ],
-          "type": "union",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": undefined,
+                "rewrite": "computed_userset",
+                "target": "writer",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "triager",
         },
-        "relation": "triager",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": undefined,
-              "rewrite": "computed_userset",
-              "target": "maintainer",
-            },
-            {
-              "from": "owner",
-              "rewrite": "tuple_to_userset",
-              "target": "repo_writer",
-            },
-          ],
-          "type": "union",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": undefined,
+                "rewrite": "computed_userset",
+                "target": "maintainer",
+              },
+              {
+                "from": "owner",
+                "rewrite": "tuple_to_userset",
+                "target": "repo_writer",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "writer",
         },
-        "relation": "writer",
-      },
-    ],
-    "type": "repo",
-  },
-  {
-    "comment": "",
-    "relations": [
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": undefined,
-              "rewrite": "computed_userset",
-              "target": "owner",
-            },
-          ],
-          "type": "union",
+      ],
+      "type": "repo",
+    },
+    {
+      "comment": "",
+      "relations": [
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": undefined,
+                "rewrite": "computed_userset",
+                "target": "owner",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "billing_manager",
         },
-        "relation": "billing_manager",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": undefined,
-              "rewrite": "computed_userset",
-              "target": "owner",
-            },
-          ],
-          "type": "union",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": undefined,
+                "rewrite": "computed_userset",
+                "target": "owner",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "member",
         },
-        "relation": "member",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "owner",
         },
-        "relation": "owner",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "repo_admin",
         },
-        "relation": "repo_admin",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "repo_reader",
         },
-        "relation": "repo_reader",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "repo_writer",
         },
-        "relation": "repo_writer",
-      },
-    ],
-    "type": "org",
-  },
-  {
-    "comment": "",
-    "relations": [
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-            {
-              "from": "owner",
-              "rewrite": "tuple_to_userset",
-              "target": "owner",
-            },
-          ],
-          "type": "union",
+      ],
+      "type": "org",
+    },
+    {
+      "comment": "",
+      "relations": [
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+              {
+                "from": "owner",
+                "rewrite": "tuple_to_userset",
+                "target": "owner",
+              },
+            ],
+            "type": "union",
+          },
+          "relation": "app_manager",
         },
-        "relation": "app_manager",
-      },
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "owner",
         },
-        "relation": "owner",
-      },
-    ],
-    "type": "app",
-  },
-]
+      ],
+      "type": "app",
+    },
+  ],
+}
 `;
 
 exports[`DSL parseDSL() should correctly parse a simple sample 1`] = `
-[
-  {
-    "comment": "",
-    "relations": [
-      {
-        "allowedTypes": [],
-        "comment": "",
-        "definition": {
-          "targets": [
-            {
-              "from": undefined,
-              "rewrite": "direct",
-              "target": undefined,
-            },
-          ],
-          "type": "single",
+{
+  "schemaVersion": "1.0",
+  "types": [
+    {
+      "comment": "",
+      "relations": [
+        {
+          "allowedTypes": [],
+          "comment": "",
+          "definition": {
+            "targets": [
+              {
+                "from": undefined,
+                "rewrite": "direct",
+                "target": undefined,
+              },
+            ],
+            "type": "single",
+          },
+          "relation": "writer",
         },
-        "relation": "writer",
-      },
-    ],
-    "type": "group",
-  },
-]
+      ],
+      "type": "group",
+    },
+  ],
+}
 `;
 
 exports[`DSL parseDSL() should correctly parse a type with no relations 1`] = `
-[
-  {
-    "comment": "",
-    "relations": [],
-    "type": "group",
-  },
-]
+{
+  "schemaVersion": "1.0",
+  "types": [
+    {
+      "comment": "",
+      "relations": [],
+      "type": "group",
+    },
+  ],
+}
 `;

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -390,6 +390,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
     "comment": "",
     "relations": [
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -410,6 +411,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
     "comment": "",
     "relations": [
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -429,6 +431,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "admin",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -448,6 +451,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "maintainer",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -462,6 +466,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "owner",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -486,6 +491,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "reader",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -505,6 +511,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "triager",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -535,6 +542,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
     "comment": "",
     "relations": [
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -554,6 +562,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "billing_manager",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -573,6 +582,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "member",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -587,6 +597,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "owner",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -601,6 +612,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "repo_admin",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -615,6 +627,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "repo_reader",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -635,6 +648,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
     "comment": "",
     "relations": [
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -654,6 +668,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
         "relation": "app_manager",
       },
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [
@@ -679,6 +694,7 @@ exports[`DSL parseDSL() should correctly parse a simple sample 1`] = `
     "comment": "",
     "relations": [
       {
+        "allowedTypes": [],
         "comment": "",
         "definition": {
           "targets": [

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -47,6 +47,7 @@ type doc
 
 exports[`friendlySyntaxToApiSyntax() should be able to handle single character type 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -62,6 +63,7 @@ exports[`friendlySyntaxToApiSyntax() should be able to handle single character t
 
 exports[`friendlySyntaxToApiSyntax() should correctly read from \`and\` definition 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -89,6 +91,7 @@ exports[`friendlySyntaxToApiSyntax() should correctly read from \`and\` definiti
 
 exports[`friendlySyntaxToApiSyntax() should correctly read from \`and\` definition with $ as prefix 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -116,6 +119,7 @@ exports[`friendlySyntaxToApiSyntax() should correctly read from \`and\` definiti
 
 exports[`friendlySyntaxToApiSyntax() should correctly read from \`basic\` definition 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -131,6 +135,7 @@ exports[`friendlySyntaxToApiSyntax() should correctly read from \`basic\` defini
 
 exports[`friendlySyntaxToApiSyntax() should correctly read from \`but not\` definition 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -156,6 +161,7 @@ exports[`friendlySyntaxToApiSyntax() should correctly read from \`but not\` defi
 
 exports[`friendlySyntaxToApiSyntax() should correctly read from \`from\` definition 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -180,6 +186,7 @@ exports[`friendlySyntaxToApiSyntax() should correctly read from \`from\` definit
 
 exports[`friendlySyntaxToApiSyntax() should correctly read from \`or\` definition 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -207,6 +214,7 @@ exports[`friendlySyntaxToApiSyntax() should correctly read from \`or\` definitio
 
 exports[`friendlySyntaxToApiSyntax() should read a complex definition 1`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -321,6 +329,7 @@ exports[`friendlySyntaxToApiSyntax() should read a complex definition 1`] = `
 
 exports[`friendlySyntaxToApiSyntax() should read a complex definition 2`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {
@@ -408,6 +417,7 @@ exports[`friendlySyntaxToApiSyntax() should read a complex definition 2`] = `
 
 exports[`friendlySyntaxToApiSyntax() should read a complex definition 3`] = `
 {
+  "schema_version": "1.0",
   "type_definitions": [
     {
       "relations": {

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -4,6 +4,7 @@ export const testModels: { name: string, json: WriteAuthorizationModelRequest, f
   {
     "name": "one type with no relations",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         {
           "type": "document",
@@ -16,6 +17,7 @@ export const testModels: { name: string, json: WriteAuthorizationModelRequest, f
   {
     "name": "one type with no relations and another with one relation",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         {
           "type": "group",
@@ -39,6 +41,7 @@ export const testModels: { name: string, json: WriteAuthorizationModelRequest, f
   {
     "name": "simple model",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         {
           "type": "document",
@@ -58,6 +61,7 @@ export const testModels: { name: string, json: WriteAuthorizationModelRequest, f
   {
     "name": "multiple types",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         {
           "type": "folder",
@@ -110,6 +114,7 @@ type document
   {
     "name": "difference",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         {
           "type": "document",
@@ -154,6 +159,7 @@ type team
   {
     "name": "intersection",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         {
           "type": "document",
@@ -220,6 +226,7 @@ type organization
   {
     "name": "relations-starting-with-as",
     "json": {
+      "schema_version": "1.0",
       "type_definitions": [
         { "type": "org", "relations": { "member": { "this": {} } } },
         {
@@ -278,6 +285,7 @@ type permission
   {
     "name": "one type with one relation that supports one type",
     "json": {
+      "schema_version": "1.1",
       "type_definitions": [
         {
           "type": "document",
@@ -302,6 +310,7 @@ type permission
   {
     "name": "one type with one relation that supports two types",
     "json": {
+      "schema_version": "1.1",
       "type_definitions": [
         {
           "type": "document",

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -294,7 +294,10 @@ type permission
         }
       ]
     },
-    "friendly": "type document\n  relations\n    define viewer: [team#member] as self\n"
+    "friendly": `type document
+  relations
+    define viewer: [team#member] as self
+`
   },
   {
     "name": "one type with one relation that supports two types",
@@ -315,6 +318,9 @@ type permission
         }
       ]
     },
-    "friendly": "type document\n  relations\n    define viewer: [user,group] as self\n"
+    "friendly": `type document
+  relations
+    define viewer: [user,group] as self
+`
   },
 ];

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -275,4 +275,46 @@ type permission
     define associated_feature as self
 `
   },
+  {
+    "name": "one type with one relation that supports one type",
+    "json": {
+      "type_definitions": [
+        {
+          "type": "document",
+          "relations": {
+            "viewer": {
+              "this": {}
+            }
+          },
+          "metadata": {
+            "relations": {
+              "viewer": { "directly_related_user_types": [{ "type": "team", "relation": "member" }] }
+            }
+          }
+        }
+      ]
+    },
+    "friendly": "type document\n  relations\n    define viewer: [team#member] as self\n"
+  },
+  {
+    "name": "one type with one relation that supports two types",
+    "json": {
+      "type_definitions": [
+        {
+          "type": "document",
+          "relations": {
+            "viewer": {
+              "this": {}
+            }
+          },
+          "metadata": {
+            "relations": {
+              "viewer": { "directly_related_user_types": [{ "type": "user" }, {"type": "group"}] }
+            }
+          }
+        }
+      ]
+    },
+    "friendly": "type document\n  relations\n    define viewer: [user,group] as self\n"
+  },
 ];


### PR DESCRIPTION
## Description
Support types when defining relations.

new DSL:

```
type document
    relations
        define viewer: [user, team#member] as self
```

new parser output:

<img width="452" alt="image" src="https://user-images.githubusercontent.com/5374887/194209740-ef307e7f-d671-4ee9-be9f-066638e168aa.png">


## References
- https://github.com/openfga/rfcs/pull/7/