### PR TITLE
fix: allow same relation in computedUserset of from clause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ VERSION.txt
 tests/coverage
 .idea/
 .vscode/
+.dccache
 
 .env
 credentials.json

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -86,7 +86,7 @@ export const checkDSL = (codeInEditor: string) => {
             const lineIndex = getLineNumber(relationName, lines);
             reporter.invalidFrom({
               lineIndex,
-              value: target.target,
+              value: target.from,
               clause: Keywords.FROM,
             });
           }

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -73,23 +73,22 @@ export const checkDSL = (codeInEditor: string) => {
             // no need to continue to parse if there is no target
             return;
           }
-          if (relationName === target.target) {
-            if (target.rewrite != RewriteType.TupleToUserset) {
-              // the error case will be relation require self reference (i.e., define owner as owner)
-              const lineIndex = getLineNumber(relationName, lines);
-              reporter.useSelf({
-                lineIndex,
-                value: relationName,
-              });
-            } else if (relationDef.definition.targets?.length === 1) {
-              // define owner as writer from owner
-              const lineIndex = getLineNumber(relationName, lines);
-              reporter.invalidFrom({
-                lineIndex,
-                value: target.target,
-                clause: Keywords.FROM,
-              });
-            }
+          if (relationName === target.target && target.rewrite != RewriteType.TupleToUserset) {
+            // the error case will be relation require self reference (i.e., define owner as owner)
+            const lineIndex = getLineNumber(relationName, lines);
+            reporter.useSelf({
+              lineIndex,
+              value: relationName,
+            });
+          }
+          if (relationName === target.from && relationDef.definition.targets?.length === 1) {
+            // define owner as writer from owner
+            const lineIndex = getLineNumber(relationName, lines);
+            reporter.invalidFrom({
+              lineIndex,
+              value: target.target,
+              clause: Keywords.FROM,
+            });
           }
 
           if (target.target && !globalRelations[target.target]) {

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -106,6 +106,8 @@ exports[`DSL checkDSL() semantics should allow model with relations starting wit
 
 exports[`DSL checkDSL() semantics should allow reference from other relation 1`] = `[]`;
 
+exports[`DSL checkDSL() semantics should allow same relation name in from 1`] = `[]`;
+
 exports[`DSL checkDSL() semantics should allow self reference 1`] = `[]`;
 
 exports[`DSL checkDSL() semantics should be able to handle more than one error 1`] = `

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -384,6 +384,23 @@ exports[`DSL checkDSL() semantics should not allow impossible self reference 1`]
 ]
 `;
 
+exports[`DSL checkDSL() semantics should not allow self reference in from relation 1`] = `
+[
+  {
+    "endColumn": 57,
+    "endLineNumber": 4,
+    "message": "Cannot self-reference (\`subscriber\`) within \`from\` clause.",
+    "relatedInformation": {
+      "type": "",
+    },
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 47,
+    "startLineNumber": 4,
+  },
+]
+`;
+
 exports[`DSL checkDSL() should correctly parse a simple sample 1`] = `[]`;
 
 exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -233,6 +233,14 @@ type document
         expect(markers).toMatchSnapshot();
       });
 
+      it ("should allow same relation name in from", () => {
+        const markers = checkDSL(`type feature
+  relations
+    define associated_plan as self
+    define subscriber as subscriber from associated_plan`);
+        expect(markers).toMatchSnapshot();
+      });
+
       it("should not allow impossible self reference", () => {
         const markers = checkDSL(`type group
   relations

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -241,6 +241,14 @@ type document
         expect(markers).toMatchSnapshot();
       });
 
+      it ("should not allow self reference in from relation", () => {
+        const markers = checkDSL(`type feature
+  relations
+    define associated_plan as self
+    define subscriber as associated_plan from subscriber`);
+        expect(markers).toMatchSnapshot();
+      });
+
       it("should not allow impossible self reference", () => {
         const markers = checkDSL(`type group
   relations


### PR DESCRIPTION
## Description

It is ok for the same relation in the computedUserset of the "from" clause. For example,
```
define subscriber as subscriber from associated_plan
```

## References
Close https://github.com/openfga/syntax-transformer/issues/69

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
