### PR TITLE
feat: validation rule for type and relation name

### DIFF
--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -189,12 +189,12 @@ export const basicValidateRelation = (
   });
 };
 
-export const checkDSL = (codeInEditor: string, options?: ValidationOptions) => {
+export const checkDSL = (codeInEditor: string, options: ValidationOptions = {}) => {
   const lines = codeInEditor.split("\n");
   const markers: any = [];
   const reporter = report({ lines, markers });
-  const typeValidation = options && options.typeValidation ? options.typeValidation : defaultTypeRule;
-  const relationValidation = options && options.relationValidation ? options.relationValidation : defaultRelationRule;
+  const typeValidation = options.typeValidation || defaultTypeRule;
+  const relationValidation = options.relationValidation || defaultRelationRule;
   const defaultRegex = new RegExp("[a-zA-Z]*");
 
   let typeRegex: ValidationRegex = {

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -10,7 +10,7 @@ import {
 } from "./parse-dsl";
 import { report } from "./reporters";
 
-interface validationRegex {
+interface ValidationRegex {
   rule: string;
   regex: RegExp;
 }
@@ -53,8 +53,8 @@ function populateRelations(
   lines: string[],
   reporter: any,
   parserResults: ParserResult,
-  typeRegex: validationRegex,
-  relationRegex: validationRegex,
+  typeRegex: ValidationRegex,
+  relationRegex: ValidationRegex,
 ): [Record<string, boolean>, Record<string, TransformedType>] {
   const globalRelations: Record<string, boolean> = { [Keywords.SELF]: true };
   const transformedTypes: Record<string, TransformedType> = {};
@@ -196,11 +196,11 @@ export const checkDSL = (
   try {
     const parserResults = parseDSL(codeInEditor);
 
-    const typeRegex: validationRegex = {
+    const typeRegex: ValidationRegex = {
       regex: new RegExp(typeValidation),
       rule: typeValidation,
     };
-    const relationRegex: validationRegex = {
+    const relationRegex: ValidationRegex = {
       regex: new RegExp(relationValidation),
       rule: relationValidation,
     };

--- a/src/default-regex.ts
+++ b/src/default-regex.ts
@@ -1,0 +1,7 @@
+// These rules should match the rules as specified in
+// https://github.com/openfga/api/blob/main/openfga/v1/openfga.proto
+
+// eslint-disable-next-line no-useless-escape
+export const defaultTypeRule = "^[^:#@\\s]{1,254}$";
+// eslint-disable-next-line no-useless-escape
+export const defaultRelationRule = "^[^:#@\\s]{1,50}$";

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -104,9 +104,12 @@ export const reportUseSelf = ({ markers, lines, lineIndex, value }: ReporterOpts
   });
 };
 
-export const reportInvalidName = ({ markers, lines, lineIndex, value, clause }: ReporterOpts) => {
+export const reportInvalidName = ({ markers, lines, lineIndex, typeName, value, clause }: ReporterOpts) => {
+  const errorMessage =
+    (typeName ? `Relation '${value}' of type '${typeName}' ` : `Type '${value}' `) +
+    `does not match naming rule: '${clause}'.`;
   reportError({
-    message: `Name '${value}' does not match naming rule: '${clause}'.`,
+    message: errorMessage,
     markers,
     lines,
     value,
@@ -219,8 +222,8 @@ export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "mark
     useSelf: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportUseSelf({ value, lineIndex, markers, lines }),
 
-    invalidName: ({ lineIndex, value, clause }: Omit<ReporterOpts, "markers" | "lines">) =>
-      reportInvalidName({ value, lineIndex, markers, lines, clause }),
+    invalidName: ({ lineIndex, value, clause, typeName }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportInvalidName({ value, lineIndex, markers, lines, clause, typeName }),
 
     reservedType: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportReservedTypeName({ value, lineIndex, markers, lines }),

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -104,6 +104,17 @@ export const reportUseSelf = ({ markers, lines, lineIndex, value }: ReporterOpts
   });
 };
 
+export const reportInvalidName = ({ markers, lines, lineIndex, value, clause }: ReporterOpts) => {
+  reportError({
+    message: `Name '${value}' does not match naming rule: '${clause}'.`,
+    markers,
+    lines,
+    value,
+    relatedInformation: { type: "invalid-name" },
+    lineIndex,
+  });
+};
+
 export const reportInvalidFrom = ({ markers, lines, lineIndex, value, clause }: ReporterOpts) => {
   reportError({
     message: `Cannot self-reference (\`${value}\`) within \`${Keywords.FROM}\` clause.`,
@@ -207,6 +218,9 @@ export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "mark
   return {
     useSelf: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportUseSelf({ value, lineIndex, markers, lines }),
+
+    invalidName: ({ lineIndex, value, clause }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportInvalidName({ value, lineIndex, markers, lines, clause }),
 
     reservedType: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportReservedTypeName({ value, lineIndex, markers, lines }),

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export const validation_cases: { name: string; friendly: string; expectedError: any }[] = [
   {
     name: "invalid type name for self",
@@ -80,6 +81,52 @@ type group
         message: "A relation cannot be named 'self' or 'this'.",
         relatedInformation: {
           type: "reserved-relation-keywords",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 12,
+        startLineNumber: 4,
+      },
+    ],
+  },
+  {
+    name: "invalid type name",
+    friendly: `type user
+type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  relations
+    define member: [user] as self
+`,
+    expectedError: [
+      {
+        endColumn: 350,
+        endLineNumber: 2,
+        message:
+          "Name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,254}$'.",
+        relatedInformation: {
+          type: "invalid-name",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 6,
+        startLineNumber: 2,
+      },
+    ],
+  },
+  {
+    name: "invalid relation name",
+    friendly: `type user
+type org
+  relations
+    define aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: [user] as self
+`,
+    expectedError: [
+      {
+        endColumn: 112,
+        endLineNumber: 4,
+        message:
+          "Name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,50}$'.",
+        relatedInformation: {
+          type: "invalid-name",
         },
         severity: 8,
         source: "linter",

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -101,7 +101,7 @@ type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         endColumn: 350,
         endLineNumber: 2,
         message:
-          "Name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,254}$'.",
+          "Type 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,254}$'.",
         relatedInformation: {
           type: "invalid-name",
         },
@@ -124,7 +124,7 @@ type org
         endColumn: 112,
         endLineNumber: 4,
         message:
-          "Name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,50}$'.",
+          "Relation 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' of type 'org' does not match naming rule: '^[^:#@\\s]{1,50}$'.",
         relatedInformation: {
           type: "invalid-name",
         },

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -1,5 +1,6 @@
 import { checkDSL } from "../src";
 import { parseDSL } from "../src/parse-dsl";
+import { ValidationOptions } from "../src/check-dsl";
 
 describe("DSL", () => {
   describe("parseDSL()", () => {
@@ -292,6 +293,52 @@ type permission
 
     def`);
         expect(markers).toMatchSnapshot();
+      });
+
+      it("should gracefully handle type regex error", () => {
+        const incorrectRegex: ValidationOptions = {
+          typeValidation: "[a-Z",
+        };
+        const markers = checkDSL(
+          `type user
+`,
+          incorrectRegex,
+        );
+        const expectError: any = [
+          {
+            endColumn: 9007199254740991,
+            endLineNumber: 2,
+            message: "Incorrect type regex specification for [a-Z",
+            severity: 8,
+            source: "linter",
+            startColumn: 0,
+            startLineNumber: 0,
+          },
+        ];
+        expect(markers).toEqual(expectError);
+      });
+
+      it("should gracefully handle relation regex error", () => {
+        const incorrectRegex: ValidationOptions = {
+          relationValidation: "[a-Z",
+        };
+        const markers = checkDSL(
+          `type user
+`,
+          incorrectRegex,
+        );
+        const expectError: any = [
+          {
+            endColumn: 9007199254740991,
+            endLineNumber: 2,
+            message: "Incorrect relation regex specification for [a-Z",
+            severity: 8,
+            source: "linter",
+            startColumn: 0,
+            startLineNumber: 0,
+          },
+        ];
+        expect(markers).toEqual(expectError);
       });
     });
   });


### PR DESCRIPTION
## Description
Allow specifying regex rule for type and relation name validation

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
