### PR TITLE
feat: specify schema version in DSL

### DIFF
--- a/src/api-to-friendly.ts
+++ b/src/api-to-friendly.ts
@@ -1,5 +1,6 @@
 import { TypeDefinition, WriteAuthorizationModelRequest, Userset, Metadata } from "@openfga/sdk";
 import { Keywords } from "./keywords";
+import { SchemaVersion } from "./parse-dsl";
 
 const readFrom = (obj: Userset, define: string[]) => {
   const childKeys = Object.keys(obj);
@@ -110,10 +111,21 @@ const apiToFriendlyType = (typeDef: TypeDefinition | TypeDefinition["relations"]
   }
 };
 
+const addSchema = (schema: string, newSyntax: string[]) => {
+  if (schema != SchemaVersion.OneDotZero) {
+    newSyntax.push(`${Keywords.MODEL}`);
+    newSyntax.push(`  ${Keywords.SCHEMA} ${schema}`);
+  }
+};
+
 export const apiSyntaxToFriendlySyntax = (
   config: WriteAuthorizationModelRequest | TypeDefinition,
   newSyntax: string[] = [],
 ): string => {
+  const schemaVersion = (config as WriteAuthorizationModelRequest)?.schema_version;
+  if (schemaVersion) {
+    addSchema(schemaVersion, newSyntax);
+  }
   const typeDefs = (config as WriteAuthorizationModelRequest)?.type_definitions;
   if (typeDefs) {
     typeDefs.forEach((typeDef) => {

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -221,6 +221,11 @@ function childDefDefined(
     case RewriteType.Direct: {
       // for this case, as long as the type / type+relation defined, we should be fine
       const fromPossibleTypes = currentRelation.allowedTypes;
+      if (!fromPossibleTypes.length) {
+        const typeIndex = getTypeLineNumber(type, lines);
+        const lineIndex = getRelationLineNumber(relation, lines, typeIndex);
+        reporter.assignableRelationMustHaveTypes({ lineIndex, value: relation });
+      }
       for (const item of fromPossibleTypes) {
         const [decodedType, decodedRelation] = destructTupleToUserset(item);
         if (decodedRelation) {
@@ -467,6 +472,13 @@ export const basicValidateRelation = (
     // parse through each of the relations to do validation
     typeDef.relations.forEach((relationDef) => {
       const { relation: relationName } = relationDef;
+
+      if (relationDef.allowedTypes.length) {
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
+        reporter.allowedTypeModel10({ lineIndex, value: relationName });
+      }
+
       const validateTargetRelation = (typeName: string, relationName: string, target: any) => {
         if (!target) {
           // no need to continue to parse if there is no target

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -30,6 +30,10 @@ const getTypeLineNumber = (typeName: string, lines: string[], skipIndex?: number
   return lines.slice(skipIndex).findIndex((line: string) => line.trim().startsWith(`type ${typeName}`)) + skipIndex;
 };
 
+const getSchemaLineNumber = (schema: string, lines: string[]) => {
+  return lines.findIndex((line: string) => line.trim().replace(/ {2,}/g, " ").startsWith(`schema ${schema}`));
+};
+
 // return the line number for the specified relation
 const getRelationLineNumber = (relation: string, lines: string[], skipIndex?: number) => {
   if (!skipIndex) {
@@ -588,8 +592,11 @@ export const checkDSL = (codeInEditor: string, options: ValidationOptions = {}) 
       case SchemaVersion.OneDotOne:
         mode11Validation(lines, reporter, markers, parserResults, transformedTypes);
         break;
-      default:
-        assertNever(schemaVersion);
+      default: {
+        const lineIndex = getSchemaLineNumber(schemaVersion, lines);
+        reporter.invalidSchemaVersion({ lineIndex, value: schemaVersion });
+        break;
+      }
     }
   } catch (e: any) {
     if (typeof e.offset !== "undefined") {

--- a/src/indent-dsl.ts
+++ b/src/indent-dsl.ts
@@ -1,4 +1,7 @@
+import { Keywords } from "./keywords";
 export const indentDSL = (rawDsl: string, removeEmptyLines = false) => {
+  const indentModel = "";
+  const indentSchema = "  ";
   const indentType = "";
   const indentRelation = "  ";
   const indentDefine = "    ";
@@ -11,6 +14,12 @@ export const indentDSL = (rawDsl: string, removeEmptyLines = false) => {
       const keyword = selectedLine.split(" ")[0];
       let indentation = "";
       switch (keyword) {
+        case Keywords.MODEL:
+          indentation = indentModel;
+          break;
+        case Keywords.SCHEMA:
+          indentation = indentSchema;
+          break;
         case "type":
           indentation = indentType;
           break;

--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -9,6 +9,8 @@ export enum Keywords {
   FROM = "from",
   BUT_NOT = "but not",
   COMMENT = "comment",
+  MODEL = "model",
+  SCHEMA = "schema",
 }
 
 export enum ReservedKeywords {

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -1,10 +1,10 @@
 @preprocessor typescript
 
-types           ->   (_newline):* (type (_relations (_multiline_comment define):+):*):* {%
+types           ->   (_newline):* (model_schema):? (type (_relations (_multiline_comment define):+):*):* {%
     // @ts-ignore
     (data) => {
         // @ts-ignore
-        const types = data[1].map((datum) => {
+        const types = data[2].map((datum) => {
             // @ts-ignore
             const relations = (datum[1] && datum[1][0] && datum[1][0][1].map(innerDatum => innerDatum[1])) || [];
 
@@ -12,11 +12,14 @@ types           ->   (_newline):* (type (_relations (_multiline_comment define):
         })
 
         // @ts-ignore
-        const hasTypes = types.some(type => type.relations.some(relation => relation.allowedTypes.length));
-        const schemaVersion = hasTypes ? "1.1" : "1.0";
+        const schemaVersion = data[1]? data[1].flat(3).join("") : "1.0";
 
         return {types: types, schemaVersion: schemaVersion}
     }
+%}
+
+model_schema    ->  _multiline_comment _model (_newline):+ _schema _spacing _version (_newline):+ {%
+    data => data[5]
 %}
 
 type            ->  _multiline_comment _type _naming (_newline):+{%
@@ -119,3 +122,7 @@ _naming         -> (("$"):? ( [a-z] | [A-Z] | [0-9] |  "_" |  "-" ):+) {%
 _optional_space -> " ":*
 _spacing        -> " ":+
 _newline        -> _optional_space "\n"
+_model          -> "model"
+_schema         -> "  schema"
+_period         -> "."
+_version        -> (([0-9]):+) _period (([0-9]):+)

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -278,6 +278,17 @@ export const reportDuplicate = ({ markers, lines, lineIndex, value }: ReporterOp
   });
 };
 
+export const reportInvalidSyntaxVersion = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  reportError({
+    markers,
+    lines,
+    lineIndex,
+    value,
+    message: `Invalid schema ${value}`,
+    relatedInformation: { type: "invalid-schema" },
+  });
+};
+
 export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "markers" | "lines">) {
   return {
     useSelf: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
@@ -312,6 +323,9 @@ export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "mark
 
     invalidType: ({ lineIndex, value, typeName }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportInvalidType({ lineIndex, value, typeName, markers, lines }),
+
+    invalidSchemaVersion: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportInvalidSyntaxVersion({ lineIndex, value, markers, lines }),
 
     invalidRelation: ({ lineIndex, value, validRelations }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportInvalidRelation({

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -135,6 +135,43 @@ export const reportInvalidFrom = ({ markers, lines, lineIndex, value, clause }: 
   });
 };
 
+export const reportAllowedTypeModel10 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  const rawLine = lines[lineIndex];
+  const actualValue = rawLine.slice(rawLine.indexOf("["), rawLine.lastIndexOf("]") + 1);
+  reportError({
+    message: `Allowed types for relation '${value}' not valid for schema 1.0`,
+    markers,
+    lineIndex,
+    lines,
+    value: actualValue,
+    relatedInformation: { type: "allowed-type-schema-10" },
+    customResolver: (wordIdx, rawLine, value) => {
+      const clauseStartsAt = rawLine.indexOf(":") + ":".length + 1;
+      wordIdx = clauseStartsAt + rawLine.slice(clauseStartsAt).indexOf(value.substring(1));
+      return wordIdx;
+    },
+  });
+};
+
+export const reportAssignableRelationMustHaveTypes = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  const rawLine = lines[lineIndex];
+  const actualValue = rawLine.includes("[")
+    ? rawLine.slice(rawLine.indexOf("["), rawLine.lastIndexOf("]") + 1)
+    : "self";
+  reportError({
+    message: `Assignable relation '${value}' must have types`,
+    markers,
+    lineIndex,
+    lines,
+    value: actualValue,
+    relatedInformation: { type: "assignable-relation-must-have-type" },
+    customResolver: (wordIdx, rawLine, value) => {
+      wordIdx = rawLine.indexOf(value.substring(1));
+      return wordIdx;
+    },
+  });
+};
+
 export const reportInvalidButNot = ({ markers, lines, lineIndex, value, clause }: ReporterOpts) => {
   reportError({
     message: `Cannot self-reference (\`${value}\`) within \`${Keywords.BUT_NOT}\` clause.`,
@@ -326,6 +363,12 @@ export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "mark
 
     invalidSchemaVersion: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportInvalidSyntaxVersion({ lineIndex, value, markers, lines }),
+
+    allowedTypeModel10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportAllowedTypeModel10({ lineIndex, markers, lines, value }),
+
+    assignableRelationMustHaveTypes: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportAssignableRelationMustHaveTypes({ lineIndex, markers, lines, value }),
 
     invalidRelation: ({ lineIndex, value, validRelations }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportInvalidRelation({

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -448,30 +448,16 @@ type group
 `,
     expectedError: [
       {
-        endColumn: 18,
+        endColumn: 26,
         endLineNumber: 9,
-        message: "`parent` is an impossible relation (no entrypoint).",
+        message: "Assignable relation 'parent' must have types",
         relatedInformation: {
-          relation: "parent",
-          type: "relation-no-entry-point",
+          type: "assignable-relation-must-have-type",
         },
         severity: 8,
         source: "linter",
-        startColumn: 12,
+        startColumn: 22,
         startLineNumber: 9,
-      },
-      {
-        endColumn: 18,
-        endLineNumber: 10,
-        message: "`viewer` is an impossible relation (no entrypoint).",
-        relatedInformation: {
-          relation: "viewer",
-          type: "relation-no-entry-point",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 12,
-        startLineNumber: 10,
       },
     ],
   },
@@ -748,16 +734,15 @@ type org
 `,
     expectedError: [
       {
-        endColumn: 18,
+        endColumn: 23,
         endLineNumber: 6,
-        message: "`member` is an impossible relation (no entrypoint).",
+        message: "Assignable relation 'member' must have types",
         relatedInformation: {
-          relation: "member",
-          type: "relation-no-entry-point",
+          type: "assignable-relation-must-have-type",
         },
         severity: 8,
         source: "linter",
-        startColumn: 12,
+        startColumn: 20,
         startLineNumber: 6,
       },
     ],
@@ -774,16 +759,15 @@ type org
 `,
     expectedError: [
       {
-        endColumn: 18,
+        endColumn: 22,
         endLineNumber: 6,
-        message: "`member` is an impossible relation (no entrypoint).",
+        message: "Assignable relation 'member' must have types",
         relatedInformation: {
-          relation: "member",
-          type: "relation-no-entry-point",
+          type: "assignable-relation-must-have-type",
         },
         severity: 8,
         source: "linter",
-        startColumn: 12,
+        startColumn: 20,
         startLineNumber: 6,
       },
     ],
@@ -809,6 +793,150 @@ type org
         source: "linter",
         startColumn: 10,
         startLineNumber: 2,
+      },
+    ],
+  },
+  {
+    name: "mode 1.0 should not have allowedType",
+    friendly: `type user
+type org
+  relations
+    define member: [user] as self
+`,
+    expectedError: [
+      {
+        endColumn: 26,
+        endLineNumber: 4,
+        message: "Allowed types for relation 'member' not valid for schema 1.0",
+        relatedInformation: {
+          type: "allowed-type-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 20,
+        startLineNumber: 4,
+      },
+    ],
+  },
+  {
+    name: "model 1.1 has no directly allowed types",
+    friendly: `model
+  schema 1.1
+type user
+type folder
+  relations
+    define parent as self
+    define viewer as self or viewer from parent
+`,
+    expectedError: [
+      {
+        endColumn: 26,
+        endLineNumber: 6,
+        message: "Assignable relation 'parent' must have types",
+        relatedInformation: {
+          type: "assignable-relation-must-have-type",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 22,
+        startLineNumber: 6,
+      },
+      {
+        endColumn: 26,
+        endLineNumber: 7,
+        message: "Assignable relation 'viewer' must have types",
+        relatedInformation: {
+          type: "assignable-relation-must-have-type",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 22,
+        startLineNumber: 7,
+      },
+    ],
+  },
+  {
+    name: "model 1.1 has no directly allowed types in viewer",
+    friendly: `model
+  schema 1.1
+type user
+type folder
+  relations
+    define parent: [folder] as self
+    define viewer as self or viewer from parent
+`,
+    expectedError: [
+      {
+        endColumn: 26,
+        endLineNumber: 7,
+        message: "Assignable relation 'viewer' must have types",
+        relatedInformation: {
+          type: "assignable-relation-must-have-type",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 22,
+        startLineNumber: 7,
+      },
+    ],
+  },
+  {
+    name: "model 1.0 should not have directly allowed types in viewer",
+    friendly: `type user
+type folder
+  relations
+    define parent: [folder] as self
+    define viewer: [user] as self or viewer from parent
+`,
+    expectedError: [
+      {
+        endColumn: 28,
+        endLineNumber: 4,
+        message: "Allowed types for relation 'parent' not valid for schema 1.0",
+        relatedInformation: {
+          type: "allowed-type-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 20,
+        startLineNumber: 4,
+      },
+      {
+        endColumn: 26,
+        endLineNumber: 5,
+        message: "Allowed types for relation 'viewer' not valid for schema 1.0",
+        relatedInformation: {
+          type: "allowed-type-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 20,
+        startLineNumber: 5,
+      },
+    ],
+  },
+  {
+    name: "mixing 1.0 and 1.1 should not be allowed as non assignable self is not allowed",
+    friendly: `model
+  schema 1.1
+type user
+type folder
+  relations
+    define reader: [user] as self
+    define viewer as self or reader
+`,
+    expectedError: [
+      {
+        endColumn: 26,
+        endLineNumber: 7,
+        message: "Assignable relation 'viewer' must have types",
+        relatedInformation: {
+          type: "assignable-relation-must-have-type",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 22,
+        startLineNumber: 7,
       },
     ],
   },

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -2,7 +2,9 @@
 export const validation_cases: { name: string; friendly: string; expectedError: any }[] = [
   {
     name: "invalid type name for self",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type self
   relations
     define member: [user] as self
@@ -10,7 +12,7 @@ type self
     expectedError: [
       {
         endColumn: 10,
-        endLineNumber: 2,
+        endLineNumber: 4,
         message: "A type cannot be named 'self' or 'this'.",
         relatedInformation: {
           type: "reserved-type-keywords",
@@ -18,14 +20,15 @@ type self
         severity: 8,
         source: "linter",
         startColumn: 6,
-        startLineNumber: 2,
+        startLineNumber: 4,
       },
     ],
   },
-
   {
     name: "invalid type name for this",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type this
   relations
     define member: [user] as self
@@ -33,7 +36,7 @@ type this
     expectedError: [
       {
         endColumn: 10,
-        endLineNumber: 2,
+        endLineNumber: 4,
         message: "A type cannot be named 'self' or 'this'.",
         relatedInformation: {
           type: "reserved-type-keywords",
@@ -41,13 +44,15 @@ type this
         severity: 8,
         source: "linter",
         startColumn: 6,
-        startLineNumber: 2,
+        startLineNumber: 4,
       },
     ],
   },
   {
     name: "invalid relation name for self",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define self: [user] as self
@@ -55,7 +60,7 @@ type group
     expectedError: [
       {
         endColumn: 16,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "A relation cannot be named 'self' or 'this'.",
         relatedInformation: {
           type: "reserved-relation-keywords",
@@ -63,13 +68,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
   {
     name: "invalid relation name for this",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define this: [user] as self
@@ -77,7 +84,7 @@ type group
     expectedError: [
       {
         endColumn: 16,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "A relation cannot be named 'self' or 'this'.",
         relatedInformation: {
           type: "reserved-relation-keywords",
@@ -85,13 +92,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
   {
     name: "invalid type name",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   relations
     define member: [user] as self
@@ -99,7 +108,7 @@ type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     expectedError: [
       {
         endColumn: 350,
-        endLineNumber: 2,
+        endLineNumber: 4,
         message:
           "Type 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,254}$'.",
         relatedInformation: {
@@ -108,13 +117,15 @@ type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         severity: 8,
         source: "linter",
         startColumn: 6,
-        startLineNumber: 2,
+        startLineNumber: 4,
       },
     ],
   },
   {
     name: "invalid relation name",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: [user] as self
@@ -122,7 +133,7 @@ type org
     expectedError: [
       {
         endColumn: 112,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message:
           "Relation 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' of type 'org' does not match naming rule: '^[^:#@\\s]{1,50}$'.",
         relatedInformation: {
@@ -131,7 +142,7 @@ type org
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
@@ -165,7 +176,9 @@ type outlet
   },
   {
     name: "no entry point for multiple type",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type team
   relations
     define parent: [group] as self
@@ -178,7 +191,7 @@ type group
     expectedError: [
       {
         endColumn: 18,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "`viewer` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "viewer",
@@ -187,12 +200,12 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
 
       {
         endColumn: 18,
-        endLineNumber: 9,
+        endLineNumber: 11,
         message: "`viewer` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "viewer",
@@ -201,23 +214,23 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 9,
+        startLineNumber: 11,
       },
     ],
   },
   {
-    // For now, we purposely add a member relation to force model be recognized as 1.1
     name: "no entry point for single type single relation",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define group as group from group
-    define member: [user] as self
 `,
     expectedError: [
       {
         endColumn: 17,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "`group` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "group",
@@ -226,19 +239,44 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
   {
-    // For now, we purposely add a member relation to force model be recognized as 1.1
     name: "no entry point for single type multiple relations",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define parent: [group] as self
     define viewer as viewer from parent
 `,
+    expectedError: [
+      {
+        endColumn: 18,
+        endLineNumber: 7,
+        message: "`viewer` is an impossible relation (no entrypoint).",
+        relatedInformation: {
+          relation: "viewer",
+          type: "relation-no-entry-point",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 12,
+        startLineNumber: 7,
+      },
+    ],
+  },
+  {
+    name: "no entry point if directly assignable value is itself",
+    friendly: `model
+  schema 1.1
+type group
+  relations
+    define viewer: [group#viewer] as self
+ `,
     expectedError: [
       {
         endColumn: 18,
@@ -256,31 +294,10 @@ type group
     ],
   },
   {
-    // For now, we purposely add a member relation to force model be recognized as 1.1
-    name: "no entry point if directly assignable value is itself",
-    friendly: `type group
-  relations
-    define viewer: [group#viewer] as self
- `,
-    expectedError: [
-      {
-        endColumn: 18,
-        endLineNumber: 3,
-        message: "`viewer` is an impossible relation (no entrypoint).",
-        relatedInformation: {
-          relation: "viewer",
-          type: "relation-no-entry-point",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 12,
-        startLineNumber: 3,
-      },
-    ],
-  },
-  {
     name: "from target relation is valid",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define parent: [group] as self
@@ -289,7 +306,7 @@ type group
     expectedError: [
       {
         endColumn: 40,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "`reader` is not a valid relation for `group`.",
         relatedInformation: {
           relation: "reader",
@@ -299,13 +316,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 22,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "from target relation is not a valid relation for the from child",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
 type group
   relations
@@ -315,7 +334,7 @@ type group
     expectedError: [
       {
         endColumn: 37,
-        endLineNumber: 6,
+        endLineNumber: 8,
         message: "`org` is not a valid relation for `group`.",
         relatedInformation: {
           relation: "org",
@@ -325,13 +344,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 22,
-        startLineNumber: 6,
+        startLineNumber: 8,
       },
     ],
   },
   {
     name: "org is not a relation for group",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
 type group
   relations
@@ -341,7 +362,7 @@ type group
     expectedError: [
       {
         endColumn: 37,
-        endLineNumber: 6,
+        endLineNumber: 8,
         message: "`org` is not a valid relation for `group`.",
         relatedInformation: {
           relation: "org",
@@ -351,13 +372,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 22,
-        startLineNumber: 6,
+        startLineNumber: 8,
       },
     ],
   },
   {
     name: "direct relation assignment not found",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
 type group
   relations
@@ -366,7 +389,7 @@ type group
     expectedError: [
       {
         endColumn: 37,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "`org` is not a valid relation for `group`.",
         relatedInformation: {
           relation: "org",
@@ -376,13 +399,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 28,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "group viewer no entry point",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define viewer: [user] as self
@@ -394,7 +419,7 @@ type group
     expectedError: [
       {
         endColumn: 18,
-        endLineNumber: 8,
+        endLineNumber: 10,
         message: "`viewer` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "viewer",
@@ -403,14 +428,16 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 8,
+        startLineNumber: 10,
       },
     ],
   },
   {
     // TODO: discuss whether parent is impossible as well
     name: "mixture of 1.0 and 1.1 should yield error",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define member: [user] as self
@@ -422,7 +449,7 @@ type group
     expectedError: [
       {
         endColumn: 18,
-        endLineNumber: 7,
+        endLineNumber: 9,
         message: "`parent` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "parent",
@@ -431,11 +458,11 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 7,
+        startLineNumber: 9,
       },
       {
         endColumn: 18,
-        endLineNumber: 8,
+        endLineNumber: 10,
         message: "`viewer` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "viewer",
@@ -444,25 +471,23 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 8,
+        startLineNumber: 10,
       },
     ],
   },
   {
-    // note that for now we have to add sub-document to trick recognition as version 1.1
     name: "cyclic loop",
-    friendly: `type document
+    friendly: `model
+  schema 1.1
+type document
   relations
     define reader as writer
     define writer as reader
-type subdocument
-  relations
-    define parent: [document] as self
 `,
     expectedError: [
       {
         endColumn: 18,
-        endLineNumber: 3,
+        endLineNumber: 5,
         message: "`reader` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "reader",
@@ -471,11 +496,11 @@ type subdocument
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 3,
+        startLineNumber: 5,
       },
       {
         endColumn: 18,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "`writer` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "writer",
@@ -484,13 +509,15 @@ type subdocument
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
   {
     name: "parent relation used inside contains a write",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type folder
   relations
     define parent: [folder] as self or parent from parent
@@ -499,7 +526,7 @@ type folder
     expectedError: [
       {
         endColumn: 58,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
           relation: "parent",
@@ -508,11 +535,11 @@ type folder
         severity: 8,
         source: "linter",
         startColumn: 52,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
       {
         endColumn: 56,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
           relation: "parent",
@@ -521,13 +548,15 @@ type folder
         severity: 8,
         source: "linter",
         startColumn: 50,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "parent relation used inside viewer contains a write",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type folder
   relations
     define root: [folder] as self
@@ -537,7 +566,7 @@ type folder
     expectedError: [
       {
         endColumn: 56,
-        endLineNumber: 6,
+        endLineNumber: 8,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
           relation: "parent",
@@ -546,13 +575,15 @@ type folder
         severity: 8,
         source: "linter",
         startColumn: 50,
-        startLineNumber: 6,
+        startLineNumber: 8,
       },
     ],
   },
   {
     name: "from is another tuple to userset",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type folder
   relations
     define root: [folder] as self
@@ -562,7 +593,7 @@ type folder
     expectedError: [
       {
         endColumn: 56,
-        endLineNumber: 6,
+        endLineNumber: 8,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
           relation: "parent",
@@ -571,13 +602,15 @@ type folder
         severity: 8,
         source: "linter",
         startColumn: 50,
-        startLineNumber: 6,
+        startLineNumber: 8,
       },
     ],
   },
   {
     name: "model 1.1 one of the intersection relation is not valid",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define member: [user] as self
@@ -586,7 +619,7 @@ type group
     expectedError: [
       {
         endColumn: 40,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
           relation: "allowed",
@@ -595,13 +628,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 33,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "model 1.1 one of the union relation is not valid",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define member: [user] as self
@@ -610,7 +645,7 @@ type group
     expectedError: [
       {
         endColumn: 39,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
           relation: "allowed",
@@ -619,13 +654,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 32,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "model 1.1 base in exclusion not valid",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define member: [user] as self
@@ -634,7 +671,7 @@ type group
     expectedError: [
       {
         endColumn: 29,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
           relation: "allowed",
@@ -643,13 +680,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 22,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "model 1.1 diff in exclusion not valid",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define member: [user] as self
@@ -658,7 +697,7 @@ type group
     expectedError: [
       {
         endColumn: 44,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
           relation: "allowed",
@@ -667,13 +706,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 37,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "model 1.1 diff in exclusion not valid and spaces are reflected correctly in error messages",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define member: [user] as self
@@ -682,7 +723,7 @@ type group
     expectedError: [
       {
         endColumn: 50,
-        endLineNumber: 5,
+        endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
           relation: "allowed",
@@ -691,13 +732,15 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 43,
-        startLineNumber: 5,
+        startLineNumber: 7,
       },
     ],
   },
   {
     name: "empty directly assignable relations with spaces should yield error",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define member: [ ] as self
@@ -706,7 +749,7 @@ type org
     expectedError: [
       {
         endColumn: 18,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "`member` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "member",
@@ -715,13 +758,15 @@ type org
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
   {
     name: "empty directly assignable relations without spaces should yield error",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define member: [] as self
@@ -730,7 +775,7 @@ type org
     expectedError: [
       {
         endColumn: 18,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "`member` is an impossible relation (no entrypoint).",
         relatedInformation: {
           relation: "member",
@@ -739,14 +784,40 @@ type org
         severity: 8,
         source: "linter",
         startColumn: 12,
-        startLineNumber: 4,
+        startLineNumber: 6,
+      },
+    ],
+  },
+  {
+    name: "unsupported schema version should yield error",
+    friendly: `model
+  schema 0.9
+type user
+type org
+  relations
+    define member: [user] as self
+`,
+    expectedError: [
+      {
+        endColumn: 13,
+        endLineNumber: 2,
+        message: "Invalid schema 0.9",
+        relatedInformation: {
+          type: "invalid-schema",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 10,
+        startLineNumber: 2,
       },
     ],
   },
   // The following are valid cases and should not result in error
   {
     name: "simple group reference to itself",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type group
   relations
     define group: [group] as self
@@ -755,7 +826,9 @@ type group
   },
   {
     name: "group has entry point to itself",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define viewer: [user] as self
@@ -768,7 +841,9 @@ type group
   },
   {
     name: "intersection with directly related",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
   relations
     define member: [user] as self
@@ -782,7 +857,9 @@ type group
   },
   {
     name: "but not with directly linked",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type docs
   relations
     define blocked: [user] as self
@@ -792,7 +869,9 @@ type docs
   },
   {
     name: "intersection with directly related and has spaces and blank lines",
-    friendly: `type user
+    friendly: `model
+  schema 1.1
+type user
 type org
 
   relations

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -307,7 +307,9 @@ type permission
         },
       ],
     },
-    friendly: `type document
+    friendly: `model
+  schema 1.1
+type document
   relations
     define viewer: [team#member] as self
 `,
@@ -332,7 +334,9 @@ type permission
         },
       ],
     },
-    friendly: `type document
+    friendly: `model
+  schema 1.1
+type document
   relations
     define viewer: [user,group] as self
 `,

--- a/tests/indent-dsl.test.ts
+++ b/tests/indent-dsl.test.ts
@@ -48,7 +48,6 @@ describe("indent-dsl", () => {
       expect(apiSyntax).toEqual(testCase.json);
     });
   });
-
   testModels.forEach((testCase) => {
     it(`should indent ${testCase.name} with empty lines not removed`, () => {
       const rawFriendly = testCase.friendly


### PR DESCRIPTION
## Description
Allow specifying schema in DSL.  For model schama version != 1.0, we will also convert it back from JSON to DSL.  For schema version 1.0, we will omit converting schama version as by default it is 1.0.  It is expected that later on we will also list out the version in the case of 1.0

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Closes #81 

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
