### PR TITLE
fix: correct error location in model 1.0

### DIFF
--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -87,15 +87,18 @@ function populateRelations(
       relations[relationName] = relationDef;
 
       if (relationName === Keywords.SELF || relationName === ReservedKeywords.THIS) {
-        const lineIndex = getRelationLineNumber(relationName, lines);
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
         reporter.reservedRelation({ lineIndex, value: relationName });
       } else if (!relationRegex.regex.test(relationName)) {
-        const lineIndex = getRelationLineNumber(relationName, lines);
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
         reporter.invalidName({ lineIndex, value: relationName, clause: relationRegex.rule, typeName });
       } else if (encounteredRelationsInType[relationName]) {
         // Check if we have any duplicate relations
         // figure out what is the lineIdx in question
-        const initialLineIdx = getRelationLineNumber(relationName, lines);
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const initialLineIdx = getRelationLineNumber(relationName, lines, typeIndex);
         const duplicateLineIdx = getRelationLineNumber(relationName, lines, initialLineIdx + 1);
         reporter.duplicateDefinition({ lineIndex: duplicateLineIdx, value: relationName });
       }
@@ -132,7 +135,8 @@ export const basicValidateRelation = (
         }
         if (relationName === target.target && target.rewrite != RewriteType.TupleToUserset) {
           // the error case will be relation require self reference (i.e., define owner as owner)
-          const lineIndex = getRelationLineNumber(relationName, lines);
+          const typeIndex = getTypeLineNumber(typeName, lines);
+          const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
           reporter.useSelf({
             lineIndex,
             value: relationName,
@@ -140,7 +144,8 @@ export const basicValidateRelation = (
         }
         if (relationName === target.from && relationDef.definition.targets?.length === 1) {
           // define owner as writer from owner
-          const lineIndex = getRelationLineNumber(relationName, lines);
+          const typeIndex = getTypeLineNumber(typeName, lines);
+          const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
           reporter.invalidFrom({
             lineIndex,
             value: target.from,
@@ -150,7 +155,8 @@ export const basicValidateRelation = (
 
         if (target.target && !globalRelations[target.target]) {
           // the target relation is not defined (i.e., define owner as foo) where foo is not defined
-          const lineIndex = getRelationLineNumber(relationName, lines);
+          const typeIndex = getTypeLineNumber(typeName, lines);
+          const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
           const value = target.target;
           reporter.invalidRelation({
             lineIndex,
@@ -161,7 +167,8 @@ export const basicValidateRelation = (
 
         if (target.from && !relationsPerType[typeName].relations[target.from]) {
           // The "from" is not defined for the current type `define owner as member from writer`
-          const lineIndex = getRelationLineNumber(relationName, lines);
+          const typeIndex = getTypeLineNumber(typeName, lines);
+          const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
           const value = target.from;
           reporter.invalidRelationWithinClause({
             typeName,

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -135,4 +135,32 @@ type org
       },
     ],
   },
+  {
+    name: "ensure errors are highlighted in the right place for same relation name across different types",
+    friendly: `type user
+type geography
+  relations
+    define parent as self
+    define can_view_locations as self or can_view_locations from parent
+
+type outlet
+  relations
+    define geography as self
+    define can_view_locations as self or can_view_locations from parent
+`,
+    expectedError: [
+      {
+        endColumn: 72,
+        endLineNumber: 10,
+        message: "The relation `parent` does not exist in type `outlet`",
+        relatedInformation: {
+          type: "",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 66,
+        startLineNumber: 10,
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Description

Handle case where same relation name is used for multiple types.

## References
Close https://github.com/openfga/syntax-transformer/issues/82


## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
