### PR TITLE
chore: add test to ensure this cannot be used in union/intersection

### DIFF
--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -97,6 +97,29 @@ type group
     ],
   },
   {
+    name: "cannot use this in mode 1.0",
+    friendly: `type document
+  relations
+    define editor as self
+    define viewer as editor or this
+`,
+    expectedError: [
+      {
+        endColumn: 36,
+        endLineNumber: 4,
+        message: "The relation `this` does not exist.",
+        relatedInformation: {
+          relation: "this",
+          type: "missing-definition",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 32,
+        startLineNumber: 4,
+      },
+    ],
+  },
+  {
     name: "invalid type name",
     friendly: `model
   schema 1.1


### PR DESCRIPTION

## Description
The functionality is already there, but we want to add unit test to ensure that `this` cannot be use as part of union/intersection.  Note that if `this` is used as type, it should already been flagged in test "invalid relation name for this".

## References
Close https://github.com/openfga/syntax-transformer/issues/33


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
