### PR TITLE
Leverage Keywords namespace for indentation tokens

### DIFF
--- a/src/indent-dsl.ts
+++ b/src/indent-dsl.ts
@@ -20,13 +20,13 @@ export const indentDSL = (rawDsl: string, removeEmptyLines = false) => {
         case Keywords.SCHEMA:
           indentation = indentSchema;
           break;
-        case "type":
+        case Keywords.NAMESPACE:
           indentation = indentType;
           break;
-        case "relations":
+        case Keywords.RELATIONS:
           indentation = indentRelation;
           break;
-        case "define":
+        case Keywords.DEFINE:
           indentation = indentDefine;
           break;
         default:


### PR DESCRIPTION
## Description

This includes tokens from Keywords constants instead of inline strings in the indenting script.

## References

N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
