### PR TITLE
feat: remove as self in model 1.1

### DIFF
--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -11,7 +11,6 @@ import {
   TransformedType,
 } from "./parse-dsl";
 import { report } from "./reporters";
-import { assertNever } from "./utils/assert-never";
 
 export interface ValidationRegex {
   rule: string;
@@ -367,6 +366,22 @@ function mode11Validation(
     // parse through each of the relations to do validation
     typeDef.relations.forEach((relationDef) => {
       const { relation: relationName } = relationDef;
+      if (relationDef.hasAs) {
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
+        reporter.asInVersion11({
+          lineIndex,
+          value: "as",
+        });
+      }
+      if (!relationDef.hasColon) {
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
+        reporter.missingColonInVersion11({
+          lineIndex,
+          value: lines[lineIndex],
+        });
+      }
 
       relationDefined(lines, reporter, relationsPerType, typeName, relationName);
     });
@@ -472,6 +487,18 @@ export const basicValidateRelation = (
     // parse through each of the relations to do validation
     typeDef.relations.forEach((relationDef) => {
       const { relation: relationName } = relationDef;
+
+      if (!relationDef.hasAs) {
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
+        reporter.missingAsInVersion10({ lineIndex, value: lines[lineIndex] });
+      }
+
+      if (relationDef.hasColon) {
+        const typeIndex = getTypeLineNumber(typeName, lines);
+        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
+        reporter.colonInVersion10({ lineIndex, value: ":" });
+      }
 
       if (relationDef.allowedTypes.length) {
         const typeIndex = getTypeLineNumber(typeName, lines);

--- a/src/check-dsl.ts
+++ b/src/check-dsl.ts
@@ -366,23 +366,6 @@ function mode11Validation(
     // parse through each of the relations to do validation
     typeDef.relations.forEach((relationDef) => {
       const { relation: relationName } = relationDef;
-      if (relationDef.hasAs) {
-        const typeIndex = getTypeLineNumber(typeName, lines);
-        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
-        reporter.asInVersion11({
-          lineIndex,
-          value: "as",
-        });
-      }
-      if (!relationDef.hasColon) {
-        const typeIndex = getTypeLineNumber(typeName, lines);
-        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
-        reporter.missingColonInVersion11({
-          lineIndex,
-          value: lines[lineIndex],
-        });
-      }
-
       relationDefined(lines, reporter, relationsPerType, typeName, relationName);
     });
   });
@@ -487,18 +470,6 @@ export const basicValidateRelation = (
     // parse through each of the relations to do validation
     typeDef.relations.forEach((relationDef) => {
       const { relation: relationName } = relationDef;
-
-      if (!relationDef.hasAs) {
-        const typeIndex = getTypeLineNumber(typeName, lines);
-        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
-        reporter.missingAsInVersion10({ lineIndex, value: lines[lineIndex] });
-      }
-
-      if (relationDef.hasColon) {
-        const typeIndex = getTypeLineNumber(typeName, lines);
-        const lineIndex = getRelationLineNumber(relationName, lines, typeIndex);
-        reporter.colonInVersion10({ lineIndex, value: ":" });
-      }
 
       if (relationDef.allowedTypes.length) {
         const typeIndex = getTypeLineNumber(typeName, lines);
@@ -647,7 +618,7 @@ export const checkDSL = (codeInEditor: string, options: ValidationOptions = {}) 
         const marker = {
           // monaco.MarkerSeverity.Error,
           severity: 8,
-          startColumn: column - 1 < 0 ? 0 : column - 1,
+          startColumn: column < 0 ? 0 : column,
           endColumn: lines[line - 1].length,
           startLineNumber: column === 0 ? line - 1 : line,
           endLineNumber: column === 0 ? line - 1 : line,

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -89,7 +89,8 @@ define_10          ->  _newline define_initial _spacing _as _spacing (define_bas
                 type: 'single',
                 targets: [def]
             }
-        const allowedTypes = def.allowedTypes;
+        // Note that this is in typescript.  Thus, if the grammer is to be used in js only environment, remove the type
+        const allowedTypes: string[] = [];
 
         return { comment, allowedTypes, relation, definition};
     }
@@ -113,28 +114,29 @@ define_11          ->  _newline define_initial _colon _spacing (define_base_11 |
 %}
 
 define_initial      -> _define _naming {%
-	data => data[1]
+    data => data[1]
 %}
 
 define_base  ->  ( _naming | from_phrase) {%
     data => {
-		const entry = data[0][0];
-		let target, rewrite, from;
+        const entry = data[0][0];
+        let target, rewrite, from;
+        // Note that this is in typescript.  Thus, if the grammer is to be used in js only environment, remove the type
         const allowedTypes: string[] = [];
-		if (typeof entry === "string") {
-			if (entry === "self") {
-				rewrite = "direct";
-			} else {
-				rewrite = "computed_userset";
-				target = entry;
-			}
-		} else {
-			from = entry.from;
-		    target = entry.target;
-			rewrite = "tuple_to_userset";
-		}
-		return { rewrite, target, from, allowedTypes  }
-	}
+        if (typeof entry === "string") {
+            if (entry === "self") {
+                rewrite = "direct";
+            } else {
+                rewrite = "computed_userset";
+                target = entry;
+            }
+        } else {
+            from = entry.from;
+            target = entry.target;
+            rewrite = "tuple_to_userset";
+        }
+        return { rewrite, target, from, allowedTypes  }
+    }
 %}
 
 define_base_11  ->  (_relation_types | _naming | from_phrase) {%
@@ -142,23 +144,24 @@ define_base_11  ->  (_relation_types | _naming | from_phrase) {%
         if (data[0][0].allowedTypes) {
             return {rewrite: "direct", target: null, from: null, allowedTypes: data[0][0].allowedTypes}
         }
-		const entry = data[0][0];
-		let target, rewrite, from;
+        const entry = data[0][0];
+        let target, rewrite, from;
+        // Note that this is in typescript.  Thus, if the grammer is to be used in js only environment, remove the type
         const allowedTypes: string[] = [];
-		if (typeof entry === "string") {
-			if (entry === "self") {
-				rewrite = "direct";
-			} else {
-				rewrite = "computed_userset";
-				target = entry;
-			}
-		} else {
-			from = entry.from;
-		    target = entry.target;
-			rewrite = "tuple_to_userset";
-		}
-		return { rewrite, target, from, allowedTypes  }
-	}
+        if (typeof entry === "string") {
+            if (entry === "self") {
+                rewrite = "direct";
+            } else {
+                rewrite = "computed_userset";
+                target = entry;
+            }
+        } else {
+            from = entry.from;
+            target = entry.target;
+            rewrite = "tuple_to_userset";
+        }
+        return { rewrite, target, from, allowedTypes  }
+    }
 %}
 
 define_or       -> define_base (_spacing _or _spacing define_base):+ {%

--- a/src/openfga.ne
+++ b/src/openfga.ne
@@ -1,6 +1,46 @@
 @preprocessor typescript
 
-types           ->   (_newline):* (model_schema):? (type (_relations (_multiline_comment define):+):*):* {%
+types           ->  (types_10 | types_10_defined | types_11) {%
+     data => {return (data[0][0]) ? data[0][0]: (data[0][1]) ? data[0][1] : data[0][2]}
+%}
+
+types_10           ->   (_newline):* (type (_relations (_multiline_comment define_10):+):*):* {%
+    // @ts-ignore
+    (data) => {
+        // @ts-ignore
+        const types = data[1].map((datum) => {
+            // @ts-ignore
+            const relations = (datum[1] && datum[1][0] && datum[1][0][1].map(innerDatum => innerDatum[1])) || [];
+
+            return { ...datum[0], relations }
+        })
+
+        // @ts-ignore
+        const schemaVersion = "1.0";
+
+        return {types: types, schemaVersion: schemaVersion}
+    }
+%}
+
+types_10_defined ->   (_newline):* model_schema_10 (type (_relations (_multiline_comment define_10):+):*):* {%
+    // @ts-ignore
+    (data) => {
+        // @ts-ignore
+        const types = data[2].map((datum) => {
+            // @ts-ignore
+            const relations = (datum[1] && datum[1][0] && datum[1][0][1].map(innerDatum => innerDatum[1])) || [];
+
+            return { ...datum[0], relations }
+        })
+
+        // @ts-ignore
+        const schemaVersion = data[1]? data[1].flat(3).join("") : "1.0";
+
+        return {types: types, schemaVersion: schemaVersion}
+    }
+%}
+
+types_11   ->   (_newline):* model_schema_11 (type (_relations (_multiline_comment define_11):+):*):* {%
     // @ts-ignore
     (data) => {
         // @ts-ignore
@@ -22,28 +62,53 @@ model_schema    ->  _multiline_comment _model (_newline):+ _schema _spacing _ver
     data => data[5]
 %}
 
+model_schema_10    ->  _multiline_comment _model (_newline):+ _schema _spacing _version_10 (_newline):+ {%
+    data => data[5]
+%}
+
+model_schema_11   ->  _multiline_comment _model (_newline):+ _schema _spacing _version_11 (_newline):+ {%
+    data => data[5]
+%}
+
+
 type            ->  _multiline_comment _type _naming (_newline):+{%
     data => ({ comment: data[0], type: data[2] })
 %}
 relations       ->  _relations {%
     data => data[0]
 %}
-define          ->  _newline define_initial (_colon):? _spacing (_as _spacing):? (define_base | define_or | define_and | define_but_not) (_newline):*  {%
+
+define_10          ->  _newline define_initial _spacing _as _spacing (define_base | define_or | define_and | define_but_not) (_newline):*  {%
     (data, _location, reject) => {
         const relation = data[1];
         // Not supported yet
         const comment = "";
         const def = data[5][0];
-        const hasAs = data[4] !== null;
         const definition = def.type ? def :
             {
                 type: 'single',
                 targets: [def]
             }
-        const hasColon = data[2] != null;
         const allowedTypes = def.allowedTypes;
 
-        return { comment, allowedTypes, relation, definition, hasColon, hasAs };
+        return { comment, allowedTypes, relation, definition};
+    }
+%}
+
+define_11          ->  _newline define_initial _colon _spacing (define_base_11 | define_or_11 | define_and_11 | define_but_not_11) (_newline):*  {%
+    (data, _location, reject) => {
+        const relation = data[1];
+        // Not supported yet
+        const comment = "";
+        const def = data[4][0];
+        const definition = def.type ? def :
+            {
+                type: 'single',
+                targets: [def]
+            }
+        const allowedTypes = def.allowedTypes;
+
+        return { comment, allowedTypes, relation, definition};
     }
 %}
 
@@ -51,7 +116,28 @@ define_initial      -> _define _naming {%
 	data => data[1]
 %}
 
-define_base  ->  (_relation_types | _naming | from_phrase) {%
+define_base  ->  ( _naming | from_phrase) {%
+    data => {
+		const entry = data[0][0];
+		let target, rewrite, from;
+        const allowedTypes: string[] = [];
+		if (typeof entry === "string") {
+			if (entry === "self") {
+				rewrite = "direct";
+			} else {
+				rewrite = "computed_userset";
+				target = entry;
+			}
+		} else {
+			from = entry.from;
+		    target = entry.target;
+			rewrite = "tuple_to_userset";
+		}
+		return { rewrite, target, from, allowedTypes  }
+	}
+%}
+
+define_base_11  ->  (_relation_types | _naming | from_phrase) {%
     data => {
         if (data[0][0].allowedTypes) {
             return {rewrite: "direct", target: null, from: null, allowedTypes: data[0][0].allowedTypes}
@@ -77,15 +163,32 @@ define_base  ->  (_relation_types | _naming | from_phrase) {%
 
 define_or       -> define_base (_spacing _or _spacing define_base):+ {%
     // @ts-ignore
+    data => ({ targets: [data[0], ...data[1].map((datum) => datum[3])], type: "union", allowedTypes:[]  })
+%}
+
+define_or_11       -> define_base_11 (_spacing _or _spacing define_base_11):+ {%
+    // @ts-ignore
     data => ({ targets: [data[0], ...data[1].map((datum) => datum[3])], type: "union", allowedTypes: data[0].allowedTypes.concat(...data[1].map((datum) => datum[3].allowedTypes)) })
 %}
+
 define_and      -> define_base (_spacing _and _spacing define_base):+ {%
+    // @ts-ignore
+    data => ({ targets: [data[0], ...data[1].map((datum) => datum[3])], type: "intersection", allowedTypes: []  })
+%}
+
+define_and_11      -> define_base_11 (_spacing _and _spacing define_base_11):+ {%
     // @ts-ignore
     data => ({ targets: [data[0], ...data[1].map((datum) => datum[3])], type: "intersection", allowedTypes: data[0].allowedTypes.concat(...data[1].map((datum) => datum[3].allowedTypes))  })
 %}
+
 define_but_not  -> define_base _spacing _but_not _spacing define_base {%
+    data => ({ base: data[0], diff: data[4], type: "exclusion", allowedTypes: [] })
+%}
+
+define_but_not_11  -> define_base_11 _spacing _but_not _spacing define_base_11 {%
     data => ({ base: data[0], diff: data[4], type: "exclusion", allowedTypes: data[0].allowedTypes })
 %}
+
 from_phrase -> _naming _spacing _from _spacing _naming {%
     data => ({ target: data[0], from: data[4] })
 %}
@@ -131,3 +234,5 @@ _model          -> "model"
 _schema         -> "  schema"
 _period         -> "."
 _version        -> (([0-9]):+) _period (([0-9]):+)
+_version_10     -> "1.0"
+_version_11     -> "1.1"

--- a/src/parse-dsl.ts
+++ b/src/parse-dsl.ts
@@ -25,6 +25,8 @@ export interface RelationDefParserResult<T extends RelationDefOperator> {
   comment: string;
   relation: string;
   allowedTypes: string[];
+  hasAs: boolean;
+  hasColon: boolean;
   definition: {
     type: T;
     targets: T extends RelationDefOperator.Exclusion ? undefined : RelationTargetParserResult[];

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -153,6 +153,53 @@ export const reportAllowedTypeModel10 = ({ markers, lines, lineIndex, value }: R
   });
 };
 
+export const reportMissingAsInVersion10 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  reportError({
+    markers,
+    lines,
+    lineIndex,
+    value,
+    message: "Missing 'as' in definition for schema 1.0",
+    relatedInformation: { type: "missing-as-schema-10" },
+  });
+};
+
+export const reportColonInVersion10 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  reportError({
+    markers,
+    lines,
+    lineIndex,
+    value,
+    message: "Colon is invalid for schema 1.0",
+    relatedInformation: { type: "colon-used-schema-10" },
+    customResolver: (wordIdx, rawLine, value) => {
+      return rawLine.indexOf(value) + 1;
+    },
+  });
+};
+
+export const reportMissingColonInVersion11 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  reportError({
+    markers,
+    lines,
+    lineIndex,
+    value,
+    message: "Missing ':' in definition for schema 1.1",
+    relatedInformation: { type: "missing-colon-schema-11" },
+  });
+};
+
+export const reportAsInVersion11 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
+  reportError({
+    markers,
+    lines,
+    lineIndex,
+    value,
+    message: "'as' is invalid for schema 1.1",
+    relatedInformation: { type: "as-used-schema-11" },
+  });
+};
+
 export const reportAssignableRelationMustHaveTypes = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
   const rawLine = lines[lineIndex];
   const actualValue = rawLine.includes("[")
@@ -366,6 +413,18 @@ export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "mark
 
     allowedTypeModel10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportAllowedTypeModel10({ lineIndex, markers, lines, value }),
+
+    missingAsInVersion10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportMissingAsInVersion10({ lineIndex, markers, lines, value }),
+
+    colonInVersion10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportColonInVersion10({ lineIndex, markers, lines, value }),
+
+    missingColonInVersion11: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportMissingColonInVersion11({ lineIndex, markers, lines, value }),
+
+    asInVersion11: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
+      reportAsInVersion11({ lineIndex, markers, lines, value }),
 
     assignableRelationMustHaveTypes: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportAssignableRelationMustHaveTypes({ lineIndex, markers, lines, value }),

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -153,53 +153,6 @@ export const reportAllowedTypeModel10 = ({ markers, lines, lineIndex, value }: R
   });
 };
 
-export const reportMissingAsInVersion10 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
-  reportError({
-    markers,
-    lines,
-    lineIndex,
-    value,
-    message: "Missing 'as' in definition for schema 1.0",
-    relatedInformation: { type: "missing-as-schema-10" },
-  });
-};
-
-export const reportColonInVersion10 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
-  reportError({
-    markers,
-    lines,
-    lineIndex,
-    value,
-    message: "Colon is invalid for schema 1.0",
-    relatedInformation: { type: "colon-used-schema-10" },
-    customResolver: (wordIdx, rawLine, value) => {
-      return rawLine.indexOf(value) + 1;
-    },
-  });
-};
-
-export const reportMissingColonInVersion11 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
-  reportError({
-    markers,
-    lines,
-    lineIndex,
-    value,
-    message: "Missing ':' in definition for schema 1.1",
-    relatedInformation: { type: "missing-colon-schema-11" },
-  });
-};
-
-export const reportAsInVersion11 = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
-  reportError({
-    markers,
-    lines,
-    lineIndex,
-    value,
-    message: "'as' is invalid for schema 1.1",
-    relatedInformation: { type: "as-used-schema-11" },
-  });
-};
-
 export const reportAssignableRelationMustHaveTypes = ({ markers, lines, lineIndex, value }: ReporterOpts) => {
   const rawLine = lines[lineIndex];
   const actualValue = rawLine.includes("[")
@@ -413,18 +366,6 @@ export const report = function ({ markers, lines }: Pick<BaseReporterOpts, "mark
 
     allowedTypeModel10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportAllowedTypeModel10({ lineIndex, markers, lines, value }),
-
-    missingAsInVersion10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
-      reportMissingAsInVersion10({ lineIndex, markers, lines, value }),
-
-    colonInVersion10: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
-      reportColonInVersion10({ lineIndex, markers, lines, value }),
-
-    missingColonInVersion11: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
-      reportMissingColonInVersion11({ lineIndex, markers, lines, value }),
-
-    asInVersion11: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
-      reportAsInVersion11({ lineIndex, markers, lines, value }),
 
     assignableRelationMustHaveTypes: ({ lineIndex, value }: Omit<ReporterOpts, "markers" | "lines">) =>
       reportAssignableRelationMustHaveTypes({ lineIndex, markers, lines, value }),

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -24,7 +24,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`and\` 1`] = `
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 28,
+    "startColumn": 29,
     "startLineNumber": 4,
   },
 ]
@@ -66,7 +66,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`but not\` 1`] =
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 32,
+    "startColumn": 33,
     "startLineNumber": 4,
   },
 ]
@@ -80,7 +80,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`define\` 1`] = 
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 6,
+    "startColumn": 7,
     "startLineNumber": 3,
   },
 ]
@@ -94,7 +94,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`or\` 1`] = `
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 27,
+    "startColumn": 28,
     "startLineNumber": 4,
   },
 ]
@@ -108,7 +108,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`self\` 1`] = `
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 24,
+    "startColumn": 25,
     "startLineNumber": 3,
   },
 ]
@@ -436,8 +436,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "member",
         },
       ],
@@ -467,8 +465,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "admin",
         },
         {
@@ -492,8 +488,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "maintainer",
         },
         {
@@ -510,8 +504,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "owner",
         },
         {
@@ -541,8 +533,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "reader",
         },
         {
@@ -566,8 +556,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "triager",
         },
         {
@@ -597,8 +585,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "writer",
         },
       ],
@@ -628,8 +614,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "billing_manager",
         },
         {
@@ -653,8 +637,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "member",
         },
         {
@@ -671,8 +653,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "owner",
         },
         {
@@ -689,8 +669,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "repo_admin",
         },
         {
@@ -707,8 +685,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "repo_reader",
         },
         {
@@ -725,8 +701,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "repo_writer",
         },
       ],
@@ -756,8 +730,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "app_manager",
         },
         {
@@ -774,8 +746,6 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "owner",
         },
       ],
@@ -806,8 +776,6 @@ exports[`DSL parseDSL() should correctly parse a simple sample 1`] = `
             ],
             "type": "single",
           },
-          "hasAs": true,
-          "hasColon": false,
           "relation": "writer",
         },
       ],

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -38,7 +38,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`as\` 1`] = `
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 19,
+    "startColumn": 20,
     "startLineNumber": 3,
   },
 ]
@@ -52,7 +52,7 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`as\` 2`] = `
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
-    "startColumn": 19,
+    "startColumn": 20,
     "startLineNumber": 3,
   },
 ]
@@ -428,6 +428,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -435,6 +436,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "member",
         },
       ],
@@ -447,13 +450,16 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": "owner",
                 "rewrite": "tuple_to_userset",
                 "target": "repo_admin",
@@ -461,19 +467,24 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "admin",
         },
         {
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "computed_userset",
                 "target": "admin",
@@ -481,6 +492,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "maintainer",
         },
         {
@@ -489,6 +502,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -496,24 +510,30 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "owner",
         },
         {
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "computed_userset",
                 "target": "triager",
               },
               {
+                "allowedTypes": [],
                 "from": "owner",
                 "rewrite": "tuple_to_userset",
                 "target": "repo_reader",
@@ -521,19 +541,24 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "reader",
         },
         {
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "computed_userset",
                 "target": "writer",
@@ -541,24 +566,30 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "triager",
         },
         {
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "computed_userset",
                 "target": "maintainer",
               },
               {
+                "allowedTypes": [],
                 "from": "owner",
                 "rewrite": "tuple_to_userset",
                 "target": "repo_writer",
@@ -566,6 +597,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "writer",
         },
       ],
@@ -578,13 +611,16 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "computed_userset",
                 "target": "owner",
@@ -592,19 +628,24 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "billing_manager",
         },
         {
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "computed_userset",
                 "target": "owner",
@@ -612,6 +653,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "member",
         },
         {
@@ -620,6 +663,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -627,6 +671,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "owner",
         },
         {
@@ -635,6 +681,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -642,6 +689,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "repo_admin",
         },
         {
@@ -650,6 +699,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -657,6 +707,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "repo_reader",
         },
         {
@@ -665,6 +717,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -672,6 +725,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "repo_writer",
         },
       ],
@@ -684,13 +739,16 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "allowedTypes": [],
           "comment": "",
           "definition": {
+            "allowedTypes": [],
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
               },
               {
+                "allowedTypes": [],
                 "from": "owner",
                 "rewrite": "tuple_to_userset",
                 "target": "owner",
@@ -698,6 +756,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "union",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "app_manager",
         },
         {
@@ -706,6 +766,7 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -713,6 +774,8 @@ exports[`DSL parseDSL() should correctly parse a complex sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "owner",
         },
       ],
@@ -735,6 +798,7 @@ exports[`DSL parseDSL() should correctly parse a simple sample 1`] = `
           "definition": {
             "targets": [
               {
+                "allowedTypes": [],
                 "from": undefined,
                 "rewrite": "direct",
                 "target": undefined,
@@ -742,6 +806,8 @@ exports[`DSL parseDSL() should correctly parse a simple sample 1`] = `
             ],
             "type": "single",
           },
+          "hasAs": true,
+          "hasColon": false,
           "relation": "writer",
         },
       ],

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -7,7 +7,7 @@ export const validation_cases: { name: string; friendly: string; expectedError: 
 type user
 type self
   relations
-    define member: [user] as self
+    define member: [user]
 `,
     expectedError: [
       {
@@ -31,7 +31,7 @@ type self
 type user
 type this
   relations
-    define member: [user] as self
+    define member: [user]
 `,
     expectedError: [
       {
@@ -55,7 +55,7 @@ type this
 type user
 type group
   relations
-    define self: [user] as self
+    define self: [user]
 `,
     expectedError: [
       {
@@ -79,7 +79,7 @@ type group
 type user
 type group
   relations
-    define this: [user] as self
+    define this: [user]
 `,
     expectedError: [
       {
@@ -126,7 +126,7 @@ type group
 type user
 type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   relations
-    define member: [user] as self
+    define member: [user]
 `,
     expectedError: [
       {
@@ -151,7 +151,7 @@ type aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 type user
 type org
   relations
-    define aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: [user] as self
+    define aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: [user]
 `,
     expectedError: [
       {
@@ -204,12 +204,12 @@ type outlet
 type user
 type team
   relations
-    define parent: [group] as self
-    define viewer as viewer from parent
+    define parent: [group]
+    define viewer: viewer from parent
 type group
   relations
-    define parent: [team] as self
-    define viewer as viewer from parent
+    define parent: [team]
+    define viewer: viewer from parent
 `,
     expectedError: [
       {
@@ -248,7 +248,7 @@ type group
 type user
 type group
   relations
-    define group as group from group
+    define group: group from group
 `,
     expectedError: [
       {
@@ -273,8 +273,8 @@ type group
 type user
 type group
   relations
-    define parent: [group] as self
-    define viewer as viewer from parent
+    define parent: [group]
+    define viewer: viewer from parent
 `,
     expectedError: [
       {
@@ -298,7 +298,7 @@ type group
   schema 1.1
 type group
   relations
-    define viewer: [group#viewer] as self
+    define viewer: [group#viewer]
  `,
     expectedError: [
       {
@@ -323,12 +323,12 @@ type group
 type user
 type group
   relations
-    define parent: [group] as self
-    define viewer as reader from parent
+    define parent: [group]
+    define viewer: reader from parent
 `,
     expectedError: [
       {
-        endColumn: 40,
+        endColumn: 38,
         endLineNumber: 7,
         message: "`reader` is not a valid relation for `group`.",
         relatedInformation: {
@@ -338,7 +338,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 22,
+        startColumn: 20,
         startLineNumber: 7,
       },
     ],
@@ -350,7 +350,7 @@ type group
 type user
 type group
   relations
-    define parent: [unknown] as self
+    define parent: [unknown]
 `,
     expectedError: [
       {
@@ -376,12 +376,12 @@ type user
 type org
 type group
   relations
-    define parent: [group] as self
-    define viewer as viewer from org
+    define parent: [group]
+    define viewer: viewer from org
 `,
     expectedError: [
       {
-        endColumn: 37,
+        endColumn: 35,
         endLineNumber: 8,
         message: "`org` is not a valid relation for `group`.",
         relatedInformation: {
@@ -391,7 +391,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 22,
+        startColumn: 20,
         startLineNumber: 8,
       },
     ],
@@ -404,12 +404,12 @@ type user
 type org
 type group
   relations
-    define parent: [group] as self
-    define viewer as org from parent
+    define parent: [group]
+    define viewer: org from parent
 `,
     expectedError: [
       {
-        endColumn: 37,
+        endColumn: 35,
         endLineNumber: 8,
         message: "`org` is not a valid relation for `group`.",
         relatedInformation: {
@@ -419,7 +419,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 22,
+        startColumn: 20,
         startLineNumber: 8,
       },
     ],
@@ -432,7 +432,7 @@ type user
 type org
 type group
   relations
-    define parent: [group, group#org] as self
+    define parent: [group, group#org]
 `,
     expectedError: [
       {
@@ -458,11 +458,11 @@ type group
 type user
 type org
   relations
-    define viewer: [user] as self
+    define viewer: [user]
 type group
   relations
-    define parent: [group] as self
-    define viewer as viewer from parent
+    define parent: [group]
+    define viewer: viewer from parent
 `,
     expectedError: [
       {
@@ -488,13 +488,37 @@ type group
 type user
 type org
   relations
-    define member: [user] as self
+    define member: [user]
 type group
   relations
     define parent as self
     define viewer as viewer from parent
 `,
     expectedError: [
+      {
+        endColumn: 21,
+        endLineNumber: 9,
+        message: "'as' is invalid for schema 1.1",
+        relatedInformation: {
+          type: "as-used-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 19,
+        startLineNumber: 9,
+      },
+      {
+        endColumn: 25,
+        endLineNumber: 9,
+        message: "Missing ':' in definition for schema 1.1",
+        relatedInformation: {
+          type: "missing-colon-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 9,
+      },
       {
         endColumn: 26,
         endLineNumber: 9,
@@ -507,6 +531,30 @@ type group
         startColumn: 22,
         startLineNumber: 9,
       },
+      {
+        endColumn: 21,
+        endLineNumber: 10,
+        message: "'as' is invalid for schema 1.1",
+        relatedInformation: {
+          type: "as-used-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 19,
+        startLineNumber: 10,
+      },
+      {
+        endColumn: 39,
+        endLineNumber: 10,
+        message: "Missing ':' in definition for schema 1.1",
+        relatedInformation: {
+          type: "missing-colon-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 10,
+      },
     ],
   },
   {
@@ -515,8 +563,8 @@ type group
   schema 1.1
 type document
   relations
-    define reader as writer
-    define writer as reader
+    define reader: writer
+    define writer: reader
 `,
     expectedError: [
       {
@@ -554,12 +602,12 @@ type document
 type user
 type folder
   relations
-    define parent: [folder] as self or parent from parent
-    define viewer: [user] as self or viewer from parent
+    define parent: [folder] or parent from parent
+    define viewer: [user] or viewer from parent
 `,
     expectedError: [
       {
-        endColumn: 58,
+        endColumn: 50,
         endLineNumber: 6,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
@@ -568,11 +616,11 @@ type folder
         },
         severity: 8,
         source: "linter",
-        startColumn: 52,
+        startColumn: 44,
         startLineNumber: 6,
       },
       {
-        endColumn: 56,
+        endColumn: 48,
         endLineNumber: 7,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
@@ -581,7 +629,7 @@ type folder
         },
         severity: 8,
         source: "linter",
-        startColumn: 50,
+        startColumn: 42,
         startLineNumber: 7,
       },
     ],
@@ -593,13 +641,13 @@ type folder
 type user
 type folder
   relations
-    define root: [folder] as self
-    define parent: [folder] as self or root
-    define viewer: [user] as self or viewer from parent
+    define root: [folder]
+    define parent: [folder] or root
+    define viewer: [user] or viewer from parent
 `,
     expectedError: [
       {
-        endColumn: 56,
+        endColumn: 48,
         endLineNumber: 8,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
@@ -608,7 +656,7 @@ type folder
         },
         severity: 8,
         source: "linter",
-        startColumn: 50,
+        startColumn: 42,
         startLineNumber: 8,
       },
     ],
@@ -620,13 +668,13 @@ type folder
 type user
 type folder
   relations
-    define root: [folder] as self
-    define parent: [folder, folder#parent] as self
-    define viewer: [user] as self or viewer from parent
+    define root: [folder]
+    define parent: [folder, folder#parent]
+    define viewer: [user] or viewer from parent
 `,
     expectedError: [
       {
-        endColumn: 56,
+        endColumn: 48,
         endLineNumber: 8,
         message: "`parent` relation used inside from allows only direct relation.",
         relatedInformation: {
@@ -635,7 +683,7 @@ type folder
         },
         severity: 8,
         source: "linter",
-        startColumn: 50,
+        startColumn: 42,
         startLineNumber: 8,
       },
     ],
@@ -647,12 +695,12 @@ type folder
 type user
 type group
   relations
-    define member: [user] as self
-    define reader as member and allowed
+    define member: [user]
+    define reader: member and allowed
 `,
     expectedError: [
       {
-        endColumn: 40,
+        endColumn: 38,
         endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
@@ -661,7 +709,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 33,
+        startColumn: 31,
         startLineNumber: 7,
       },
     ],
@@ -673,12 +721,12 @@ type group
 type user
 type group
   relations
-    define member: [user] as self
-    define reader as member or allowed
+    define member: [user]
+    define reader: member or allowed
 `,
     expectedError: [
       {
-        endColumn: 39,
+        endColumn: 37,
         endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
@@ -687,7 +735,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 32,
+        startColumn: 30,
         startLineNumber: 7,
       },
     ],
@@ -699,12 +747,12 @@ type group
 type user
 type group
   relations
-    define member: [user] as self
-    define reader as allowed but not member
+    define member: [user]
+    define reader: allowed but not member
 `,
     expectedError: [
       {
-        endColumn: 29,
+        endColumn: 27,
         endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
@@ -713,7 +761,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 22,
+        startColumn: 20,
         startLineNumber: 7,
       },
     ],
@@ -725,12 +773,12 @@ type group
 type user
 type group
   relations
-    define member: [user] as self
-    define reader as member but not allowed
+    define member: [user]
+    define reader: member but not allowed
 `,
     expectedError: [
       {
-        endColumn: 44,
+        endColumn: 42,
         endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
@@ -739,7 +787,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 37,
+        startColumn: 35,
         startLineNumber: 7,
       },
     ],
@@ -751,12 +799,12 @@ type group
 type user
 type group
   relations
-    define member: [user] as self
-    define reader   as member   but not   allowed
+    define member: [user]
+    define reader   : member   but not   allowed
 `,
     expectedError: [
       {
-        endColumn: 50,
+        endColumn: 49,
         endLineNumber: 7,
         message: "The relation `allowed` does not exist.",
         relatedInformation: {
@@ -765,7 +813,7 @@ type group
         },
         severity: 8,
         source: "linter",
-        startColumn: 43,
+        startColumn: 42,
         startLineNumber: 7,
       },
     ],
@@ -777,8 +825,8 @@ type group
 type user
 type org
   relations
-    define member: [ ] as self
-    define reader: [user] as self
+    define member: [ ]
+    define reader: [user]
 `,
     expectedError: [
       {
@@ -802,8 +850,8 @@ type org
 type user
 type org
   relations
-    define member: [] as self
-    define reader: [user] as self
+    define member: []
+    define reader: [user]
 `,
     expectedError: [
       {
@@ -827,7 +875,7 @@ type org
 type user
 type org
   relations
-    define member: [user] as self
+    define member: [user]
 `,
     expectedError: [
       {
@@ -849,9 +897,33 @@ type org
     friendly: `type user
 type org
   relations
-    define member: [user] as self
+    define member: [user]
 `,
     expectedError: [
+      {
+        endColumn: 25,
+        endLineNumber: 4,
+        message: "Missing 'as' in definition for schema 1.0",
+        relatedInformation: {
+          type: "missing-as-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 4,
+      },
+      {
+        endColumn: 19,
+        endLineNumber: 4,
+        message: "Colon is invalid for schema 1.0",
+        relatedInformation: {
+          type: "colon-used-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 18,
+        startLineNumber: 4,
+      },
       {
         endColumn: 26,
         endLineNumber: 4,
@@ -867,53 +939,40 @@ type org
     ],
   },
   {
-    name: "model 1.1 has no directly allowed types",
-    friendly: `model
-  schema 1.1
-type user
-type folder
-  relations
-    define parent as self
-    define viewer as self or viewer from parent
-`,
-    expectedError: [
-      {
-        endColumn: 26,
-        endLineNumber: 6,
-        message: "Assignable relation 'parent' must have types",
-        relatedInformation: {
-          type: "assignable-relation-must-have-type",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 22,
-        startLineNumber: 6,
-      },
-      {
-        endColumn: 26,
-        endLineNumber: 7,
-        message: "Assignable relation 'viewer' must have types",
-        relatedInformation: {
-          type: "assignable-relation-must-have-type",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 22,
-        startLineNumber: 7,
-      },
-    ],
-  },
-  {
     name: "model 1.1 has no directly allowed types in viewer",
     friendly: `model
   schema 1.1
 type user
 type folder
   relations
-    define parent: [folder] as self
+    define parent: [folder]
     define viewer as self or viewer from parent
 `,
     expectedError: [
+      {
+        endColumn: 21,
+        endLineNumber: 7,
+        message: "'as' is invalid for schema 1.1",
+        relatedInformation: {
+          type: "as-used-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 19,
+        startLineNumber: 7,
+      },
+      {
+        endColumn: 47,
+        endLineNumber: 7,
+        message: "Missing ':' in definition for schema 1.1",
+        relatedInformation: {
+          type: "missing-colon-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 7,
+      },
       {
         endColumn: 26,
         endLineNumber: 7,
@@ -933,10 +992,34 @@ type folder
     friendly: `type user
 type folder
   relations
-    define parent: [folder] as self
-    define viewer: [user] as self or viewer from parent
+    define parent: [folder]
+    define viewer: [user] or viewer from parent
 `,
     expectedError: [
+      {
+        endColumn: 27,
+        endLineNumber: 4,
+        message: "Missing 'as' in definition for schema 1.0",
+        relatedInformation: {
+          type: "missing-as-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 4,
+      },
+      {
+        endColumn: 19,
+        endLineNumber: 4,
+        message: "Colon is invalid for schema 1.0",
+        relatedInformation: {
+          type: "colon-used-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 18,
+        startLineNumber: 4,
+      },
       {
         endColumn: 28,
         endLineNumber: 4,
@@ -948,6 +1031,30 @@ type folder
         source: "linter",
         startColumn: 20,
         startLineNumber: 4,
+      },
+      {
+        endColumn: 47,
+        endLineNumber: 5,
+        message: "Missing 'as' in definition for schema 1.0",
+        relatedInformation: {
+          type: "missing-as-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 5,
+      },
+      {
+        endColumn: 19,
+        endLineNumber: 5,
+        message: "Colon is invalid for schema 1.0",
+        relatedInformation: {
+          type: "colon-used-schema-10",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 18,
+        startLineNumber: 5,
       },
       {
         endColumn: 26,
@@ -970,10 +1077,34 @@ type folder
 type user
 type folder
   relations
-    define reader: [user] as self
+    define reader: [user]
     define viewer as self or reader
 `,
     expectedError: [
+      {
+        endColumn: 21,
+        endLineNumber: 7,
+        message: "'as' is invalid for schema 1.1",
+        relatedInformation: {
+          type: "as-used-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 19,
+        startLineNumber: 7,
+      },
+      {
+        endColumn: 35,
+        endLineNumber: 7,
+        message: "Missing ':' in definition for schema 1.1",
+        relatedInformation: {
+          type: "missing-colon-schema-11",
+        },
+        severity: 8,
+        source: "linter",
+        startColumn: 0,
+        startLineNumber: 7,
+      },
       {
         endColumn: 26,
         endLineNumber: 7,
@@ -996,7 +1127,7 @@ type folder
 type user
 type group
   relations
-    define group: [group] as self
+    define group: [group]
 `,
     expectedError: [],
   },
@@ -1007,11 +1138,11 @@ type group
 type user
 type org
   relations
-    define viewer: [user] as self
+    define viewer: [user]
 type group
   relations
-    define parent: [group, org] as self
-    define viewer as viewer from parent
+    define parent: [group, org]
+    define viewer: viewer from parent
 `,
     expectedError: [],
   },
@@ -1022,12 +1153,60 @@ type group
 type user
 type org
   relations
-    define member: [user] as self
+    define member: [user]
 type group
   relations
-    define parent: [group] as self
-    define writer: [user, org#member] as self
-    define viewer: [user, org#member] as self or writer
+    define parent: [group]
+    define writer: [user, org#member]
+    define viewer: [user, org#member] or writer
+`,
+    expectedError: [],
+  },
+  {
+    name: "should allow directly assigned as last item",
+    friendly: `model
+  schema 1.1
+type user
+type org
+  relations
+    define member: [user]
+type group
+  relations
+    define parent: [group]
+    define writer: [user, org#member]
+    define viewer: writer or [user, org#member]
+`,
+    expectedError: [],
+  },
+  {
+    name: "union with directly related",
+    friendly: `model
+  schema 1.1
+type user
+type org
+  relations
+    define member: [user]
+type group
+  relations
+    define parent: [group]
+    define writer: [user, org#member]
+    define viewer: [user, org#member] and writer
+`,
+    expectedError: [],
+  },
+  {
+    name: "union allow directly assigned as last item",
+    friendly: `model
+  schema 1.1
+type user
+type org
+  relations
+    define member: [user]
+type group
+  relations
+    define parent: [group]
+    define writer: [user, org#member]
+    define viewer: writer and [user, org#member]
 `,
     expectedError: [],
   },
@@ -1038,8 +1217,8 @@ type group
 type user
 type docs
   relations
-    define blocked: [user] as self
-    define can_view: [user] as self but not blocked
+    define blocked: [user]
+    define can_view: [user] but not blocked
 `,
     expectedError: [],
   },
@@ -1051,13 +1230,39 @@ type user
 type org
 
   relations
-    define member: [user] as     self   
+    define member: [user]    
 
 type group
   relations
-    define parent: [group] as self
-    define writer: [user, org#member] as self
-    define viewer:    [   user,    org#member   ]     as    self    or    writer
+    define parent: [group]
+    define writer: [user, org#member]
+    define viewer:    [   user,    org#member   ]       or    writer
+`,
+    expectedError: [],
+  },
+  {
+    name: "model 1.0 does not assert impossible relation",
+    friendly: `type user
+type folder
+  relations
+    define parent as self
+    define viewer as self or viewer from parent
+`,
+    expectedError: [],
+  },
+  {
+    name: "model 1.1 tuple to userset",
+    friendly: `model
+  schema 1.1
+type folder
+  relations
+    define viewer: [user]
+
+type document
+  relations
+    define parent: [folder]
+    define viewer: [user] or viewer from parent
+type user
 `,
     expectedError: [],
   },

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -496,64 +496,13 @@ type group
 `,
     expectedError: [
       {
-        endColumn: 21,
-        endLineNumber: 9,
-        message: "'as' is invalid for schema 1.1",
-        relatedInformation: {
-          type: "as-used-schema-11",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 19,
-        startLineNumber: 9,
-      },
-      {
         endColumn: 25,
         endLineNumber: 9,
-        message: "Missing ':' in definition for schema 1.1",
-        relatedInformation: {
-          type: "missing-colon-schema-11",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 0,
-        startLineNumber: 9,
-      },
-      {
-        endColumn: 26,
-        endLineNumber: 9,
-        message: "Assignable relation 'parent' must have types",
-        relatedInformation: {
-          type: "assignable-relation-must-have-type",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 22,
-        startLineNumber: 9,
-      },
-      {
-        endColumn: 21,
-        endLineNumber: 10,
-        message: "'as' is invalid for schema 1.1",
-        relatedInformation: {
-          type: "as-used-schema-11",
-        },
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 19,
-        startLineNumber: 10,
-      },
-      {
-        endColumn: 39,
-        endLineNumber: 10,
-        message: "Missing ':' in definition for schema 1.1",
-        relatedInformation: {
-          type: "missing-colon-schema-11",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 0,
-        startLineNumber: 10,
+        startLineNumber: 9,
       },
     ],
   },
@@ -879,12 +828,9 @@ type org
 `,
     expectedError: [
       {
-        endColumn: 13,
+        endColumn: 12,
         endLineNumber: 2,
-        message: "Invalid schema 0.9",
-        relatedInformation: {
-          type: "invalid-schema",
-        },
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 10,
@@ -893,7 +839,7 @@ type org
     ],
   },
   {
-    name: "mode 1.0 should not have allowedType",
+    name: "model 1.0 should not have allowedType",
     friendly: `type user
 type org
   relations
@@ -903,37 +849,10 @@ type org
       {
         endColumn: 25,
         endLineNumber: 4,
-        message: "Missing 'as' in definition for schema 1.0",
-        relatedInformation: {
-          type: "missing-as-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 0,
-        startLineNumber: 4,
-      },
-      {
-        endColumn: 19,
-        endLineNumber: 4,
-        message: "Colon is invalid for schema 1.0",
-        relatedInformation: {
-          type: "colon-used-schema-10",
-        },
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 18,
-        startLineNumber: 4,
-      },
-      {
-        endColumn: 26,
-        endLineNumber: 4,
-        message: "Allowed types for relation 'member' not valid for schema 1.0",
-        relatedInformation: {
-          type: "allowed-type-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 20,
         startLineNumber: 4,
       },
     ],
@@ -950,39 +869,12 @@ type folder
 `,
     expectedError: [
       {
-        endColumn: 21,
+        endColumn: 47,
         endLineNumber: 7,
-        message: "'as' is invalid for schema 1.1",
-        relatedInformation: {
-          type: "as-used-schema-11",
-        },
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 19,
-        startLineNumber: 7,
-      },
-      {
-        endColumn: 47,
-        endLineNumber: 7,
-        message: "Missing ':' in definition for schema 1.1",
-        relatedInformation: {
-          type: "missing-colon-schema-11",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 0,
-        startLineNumber: 7,
-      },
-      {
-        endColumn: 26,
-        endLineNumber: 7,
-        message: "Assignable relation 'viewer' must have types",
-        relatedInformation: {
-          type: "assignable-relation-must-have-type",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 22,
         startLineNumber: 7,
       },
     ],
@@ -999,74 +891,11 @@ type folder
       {
         endColumn: 27,
         endLineNumber: 4,
-        message: "Missing 'as' in definition for schema 1.0",
-        relatedInformation: {
-          type: "missing-as-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 0,
-        startLineNumber: 4,
-      },
-      {
-        endColumn: 19,
-        endLineNumber: 4,
-        message: "Colon is invalid for schema 1.0",
-        relatedInformation: {
-          type: "colon-used-schema-10",
-        },
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 18,
         startLineNumber: 4,
-      },
-      {
-        endColumn: 28,
-        endLineNumber: 4,
-        message: "Allowed types for relation 'parent' not valid for schema 1.0",
-        relatedInformation: {
-          type: "allowed-type-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 20,
-        startLineNumber: 4,
-      },
-      {
-        endColumn: 47,
-        endLineNumber: 5,
-        message: "Missing 'as' in definition for schema 1.0",
-        relatedInformation: {
-          type: "missing-as-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 0,
-        startLineNumber: 5,
-      },
-      {
-        endColumn: 19,
-        endLineNumber: 5,
-        message: "Colon is invalid for schema 1.0",
-        relatedInformation: {
-          type: "colon-used-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 18,
-        startLineNumber: 5,
-      },
-      {
-        endColumn: 26,
-        endLineNumber: 5,
-        message: "Allowed types for relation 'viewer' not valid for schema 1.0",
-        relatedInformation: {
-          type: "allowed-type-schema-10",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 20,
-        startLineNumber: 5,
       },
     ],
   },
@@ -1082,44 +911,56 @@ type folder
 `,
     expectedError: [
       {
-        endColumn: 21,
+        endColumn: 35,
         endLineNumber: 7,
-        message: "'as' is invalid for schema 1.1",
-        relatedInformation: {
-          type: "as-used-schema-11",
-        },
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 19,
         startLineNumber: 7,
       },
+    ],
+  },
+  {
+    name: "syntax error is highlighted in the right spot",
+    friendly: `type user
+type group
+  relations
+    define group: [group] as self
+`,
+    expectedError: [
       {
-        endColumn: 35,
-        endLineNumber: 7,
-        message: "Missing ':' in definition for schema 1.1",
-        relatedInformation: {
-          type: "missing-colon-schema-11",
-        },
+        endColumn: 33,
+        endLineNumber: 4,
+        message: "Invalid syntax",
         severity: 8,
         source: "linter",
-        startColumn: 0,
-        startLineNumber: 7,
-      },
-      {
-        endColumn: 26,
-        endLineNumber: 7,
-        message: "Assignable relation 'viewer' must have types",
-        relatedInformation: {
-          type: "assignable-relation-must-have-type",
-        },
-        severity: 8,
-        source: "linter",
-        startColumn: 22,
-        startLineNumber: 7,
+        startColumn: 17,
+        startLineNumber: 4,
       },
     ],
   },
   // The following are valid cases and should not result in error
+  {
+    name: "simple model 1.0",
+    friendly: `type user
+type group
+  relations
+    define member as self
+`,
+    expectedError: [],
+  },
+  {
+    name: "simple model where the model is explicit",
+    friendly: `model
+  schema 1.0
+type user
+type group
+  relations
+    define member as self
+`,
+    expectedError: [],
+  },
   {
     name: "simple group reference to itself",
     friendly: `model

--- a/tests/data/test-models.ts
+++ b/tests/data/test-models.ts
@@ -224,6 +224,252 @@ type organization
 `,
   },
   {
+    name: "union for 1.1",
+    json: {
+      schema_version: "1.1",
+      type_definitions: [
+        {
+          type: "user",
+          relations: {},
+        },
+        {
+          type: "document",
+          relations: {
+            owner: {
+              this: {},
+            },
+            writer: {
+              union: {
+                child: [
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "owner",
+                    },
+                  },
+                  {
+                    this: {},
+                  },
+                ],
+              },
+            },
+            reader: {
+              union: {
+                child: [
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "owner",
+                    },
+                  },
+                  {
+                    this: {},
+                  },
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "writer",
+                    },
+                  },
+                ],
+              },
+            },
+            can_write: {
+              computedUserset: {
+                object: "",
+                relation: "writer",
+              },
+            },
+            can_delete: {
+              intersection: {
+                child: [
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "writer",
+                    },
+                  },
+                  {
+                    tupleToUserset: {
+                      tupleset: {
+                        object: "",
+                        relation: "owner",
+                      },
+                      computedUserset: {
+                        object: "",
+                        relation: "member",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          metadata: {
+            relations: {
+              owner: { directly_related_user_types: [{ type: "user" }] },
+              writer: { directly_related_user_types: [{ type: "user" }] },
+              reader: { directly_related_user_types: [{ type: "user" }] },
+              can_write: { directly_related_user_types: [] },
+              can_delete: { directly_related_user_types: [] },
+            },
+          },
+        },
+        {
+          type: "organization",
+          relations: {
+            member: {
+              this: {},
+            },
+          },
+          metadata: {
+            relations: {
+              member: { directly_related_user_types: [{ type: "user" }] },
+            },
+          },
+        },
+      ],
+    },
+    friendly: `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define writer: owner or [user]
+    define reader: owner or [user] or writer
+    define can_write: writer
+    define can_delete: writer and member from owner
+type organization
+  relations
+    define member: [user]
+`,
+  },
+  {
+    name: "intersection for 1.1",
+    json: {
+      schema_version: "1.1",
+      type_definitions: [
+        {
+          type: "user",
+          relations: {},
+        },
+        {
+          type: "document",
+          relations: {
+            allowed: {
+              this: {},
+            },
+            member: {
+              this: {},
+            },
+            writer: {
+              intersection: {
+                child: [
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "member",
+                    },
+                  },
+                  {
+                    this: {},
+                  },
+                ],
+              },
+            },
+            reader: {
+              intersection: {
+                child: [
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "member",
+                    },
+                  },
+                  {
+                    this: {},
+                  },
+                  {
+                    computedUserset: {
+                      object: "",
+                      relation: "allowed",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          metadata: {
+            relations: {
+              allowed: { directly_related_user_types: [{ type: "user" }] },
+              member: { directly_related_user_types: [{ type: "user" }] },
+              writer: { directly_related_user_types: [{ type: "user" }] },
+              reader: { directly_related_user_types: [{ type: "user" }] },
+            },
+          },
+        },
+      ],
+    },
+    friendly: `model
+  schema 1.1
+type user
+type document
+  relations
+    define allowed: [user]
+    define member: [user]
+    define writer: member and [user]
+    define reader: member and [user] and allowed
+`,
+  },
+  {
+    name: "difference for model 1.1",
+    json: {
+      schema_version: "1.1",
+      type_definitions: [
+        {
+          type: "document",
+          relations: {
+            blocked: {
+              this: {},
+            },
+            editor: {
+              difference: {
+                base: {
+                  this: {},
+                },
+                subtract: {
+                  computedUserset: {
+                    object: "",
+                    relation: "blocked",
+                  },
+                },
+              },
+            },
+          },
+          metadata: {
+            relations: {
+              blocked: { directly_related_user_types: [{ type: "user" }] },
+              editor: { directly_related_user_types: [{ type: "user" }] },
+            },
+          },
+        },
+        {
+          type: "user",
+          relations: {},
+        },
+      ],
+    },
+    friendly: `model
+  schema 1.1
+type document
+  relations
+    define blocked: [user]
+    define editor: [user] but not blocked
+type user
+`,
+  },
+  {
     name: "relations-starting-with-as",
     json: {
       schema_version: "1.0",
@@ -311,7 +557,7 @@ type permission
   schema 1.1
 type document
   relations
-    define viewer: [team#member] as self
+    define viewer: [team#member]
 `,
   },
   {
@@ -338,7 +584,7 @@ type document
   schema 1.1
 type document
   relations
-    define viewer: [user,group] as self
+    define viewer: [user,group]
 `,
   },
 ];

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -224,43 +224,51 @@ type group
     });
 
     it("should only return single result for simple 1.1 valid model", () => {
-      const result = innerParseDSL(`type user
+      const result = innerParseDSL(`model
+  schema 1.1
+type user
 type team
   relations
-    define member: [user] as self
-    define other: [user] as self
+    define member: [user]
+    define other: [user]
 `);
       expect(result.length).toEqual(1);
     });
 
     it("should only return single result for simple 1.1 valid model with spaces", () => {
-      const result = innerParseDSL(`type user
+      const result = innerParseDSL(`model
+  schema 1.1
+type user
 type team
   relations
-    define member: [user]   as self 
-    define other:   [user] as   self
+    define member: [user]
+    define other:   [user]
 `);
       expect(result.length).toEqual(1);
     });
 
     it.skip("should only return single result for simple 1.1 valid model with comment", () => {
-      const result = innerParseDSL(`type user
+      const result = innerParseDSL(`model
+   schema 1.1
+type user
 type team
   relations
-    define member: [user] as self
+    define member: [user]
     # Comment for other
-    define other: [user] as self
+    define other: [user]
 `);
       expect(result.length).toEqual(1);
     });
 
     it.skip("should only return single result for simple 1.1 valid model with comment and spaces at the end", () => {
-      const result = innerParseDSL(`type user
+      const result = innerParseDSL(`model
+  schema 1.1
+type user
 type team
   relations
-    define member: [user] as self
+    define member: [user]
     # Comment for other   
-    define other: [user] as self
+    define other: [user]
 `);
       expect(result.length).toEqual(1);
     });
@@ -328,6 +336,41 @@ type app
       expect(result.length).toEqual(1);
     });
 
+    it("should only return single result for complex 1.1 model with spaces", () => {
+      const result = innerParseDSL(`model
+  schema 1.1
+type user
+type team
+  relations
+    define member: [user]  
+
+type repo
+  relations
+
+    define admin: [user] or repo_admin from owner  
+    define maintainer: [user] or admin 
+    define owner: [user]
+    define reader:   [user]   or triager  or   repo_reader from owner
+    define triager: [user] or writer
+    define writer: [user] or maintainer or repo_writer  from   owner
+    
+type org
+  relations
+    define billing_manager: [user] or owner
+    define member: [user] or owner
+    define owner:   [user]
+    define repo_admin: [user]
+    define repo_reader: [user]
+    define repo_writer: [user]
+    
+type app
+  relations
+    define app_manager: [user] or owner from owner
+    define owner: [user]
+`);
+      expect(result.length).toEqual(1);
+    });
+
     it("should parse DSL in reasonable time", () => {
       const time1 = new Date();
       // Add in addition `define R as X from Y but not Z` to increase the time
@@ -358,6 +401,44 @@ type T4
 type T5
   relations
     define A as A1 from A2 but not A3
+`);
+      const time2 = new Date();
+      expect(result.length).toEqual(1);
+      expect(time2.getTime() - time1.getTime()).toBeLessThan(1000);
+    });
+
+    it("should parse 1.1 DSL in reasonable time", () => {
+      const time1 = new Date();
+      // Add in addition `define R as X from Y but not Z` to increase the time
+      const result = innerParseDSL(`model
+  schema 1.1
+type T1
+  relations
+    define A: A1 from A2 but not A3
+    define B: B1 from B2 but not B3
+    define C: C1 from C2 but not C3
+    define D: D1 from D2 but not D3
+type T2
+  relations
+    define A: A1 from A2 but not A3
+    define B: B1 from B2 but not B3
+    define C: C1 from C2 but not C3
+    define D: D1 from D2 but not D3
+type T3
+  relations
+    define A: A1 from A2 but not A3
+    define B: B1 from B2 but not B3
+    define C: C1 from C2 but not C3
+    define D: D1 from D2 but not D3
+type T4
+  relations
+    define A: A1 from A2 but not A3
+    define B: B1 from B2 but not B3
+    define C: C1 from C2 but not C3
+    define D: D1 from D2 but not D3
+type T5
+  relations
+    define A: A1 from A2 but not A3
 `);
       const time2 = new Date();
       expect(result.length).toEqual(1);

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -372,7 +372,6 @@ type app
     });
 
     it("should parse DSL in reasonable time", () => {
-      const time1 = new Date();
       // Add in addition `define R as X from Y but not Z` to increase the time
       const result = innerParseDSL(`type T1
   relations
@@ -402,13 +401,10 @@ type T5
   relations
     define A as A1 from A2 but not A3
 `);
-      const time2 = new Date();
       expect(result.length).toEqual(1);
-      expect(time2.getTime() - time1.getTime()).toBeLessThan(1000);
-    });
+    }, 1000);
 
     it("should parse 1.1 DSL in reasonable time", () => {
-      const time1 = new Date();
       // Add in addition `define R as X from Y but not Z` to increase the time
       const result = innerParseDSL(`model
   schema 1.1
@@ -440,10 +436,8 @@ type T5
   relations
     define A: A1 from A2 but not A3
 `);
-      const time2 = new Date();
       expect(result.length).toEqual(1);
-      expect(time2.getTime() - time1.getTime()).toBeLessThan(1000);
-    });
+    }, 1000);
   });
 
   describe("checkDSL()", () => {


### PR DESCRIPTION

## Description
1. For model 1.1, do not use 'as self'.  Instead, always use ':'
2. Validate to ensure 1.0 still use 'as self' and contains no ':'

## References
Close https://github.com/openfga/syntax-transformer/issues/92

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
