### PR TITLE
chore: export default 1.1 model

### DIFF
--- a/src/default/index.ts
+++ b/src/default/index.ts
@@ -1,0 +1,24 @@
+import { SINGLE_INDENTATION } from "../formatter/indent-dsl";
+import { Keyword } from "../constants/keyword";
+
+export const DefaultOneDotOneModel = `${Keyword.MODEL}
+${SINGLE_INDENTATION}${Keyword.SCHEMA} 1.1
+${Keyword.TYPE} user
+${Keyword.TYPE} group
+${SINGLE_INDENTATION}${Keyword.RELATIONS}
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}member: [user]
+${Keyword.TYPE} folder
+${SINGLE_INDENTATION}${Keyword.RELATIONS}
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}parent: [folder]
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}owner: [user, group#member]
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}viewer: [user, group#member] ${Keyword.OR} owner ${Keyword.OR} viewer ${Keyword.FROM} parent
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}create_file: owner
+${Keyword.TYPE} doc
+${SINGLE_INDENTATION}${Keyword.RELATIONS}
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}parent: [doc]
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}owner: [user, group#member]
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}viewer: [user, group#member]
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}read: viewer ${Keyword.OR} owner ${Keyword.OR} viewer ${Keyword.FROM} parent
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}write: owner ${Keyword.OR} owner ${Keyword.FROM} parent
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}share: owner
+${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}change_owner: owner`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import transformer from "./transformer";
 import validator from "./validator";
 import * as syntaxHighlighters from "./syntax-highlighters";
 import * as theming from "./theme";
+import { DefaultOneDotOneModel } from "./default";
 
 const { Keyword, SchemaVersion } = enums;
 
@@ -18,6 +19,7 @@ export {
   validator,
   syntaxHighlighters,
   theming,
+  DefaultOneDotOneModel,
 
   // for backward compatibility to prevent breaking changes, to be removed in next major release
   Keyword,

--- a/src/syntax-highlighters/monaco/providers/completion.ts
+++ b/src/syntax-highlighters/monaco/providers/completion.ts
@@ -7,6 +7,7 @@ import { SINGLE_INDENTATION } from "../../../formatter/indent-dsl";
 import { Keyword } from "../../../constants/keyword";
 import { assertNever } from "../../../inner-utils/assert-never";
 import { SchemaVersion } from "../../../constants/schema-version";
+import { DefaultOneDotOneModel } from "../../../default";
 
 const provideCompletionItemsOneDotZero =
   (monaco: typeof MonacoEditor) =>
@@ -364,28 +365,7 @@ ${SINGLE_INDENTATION}${Keyword.SCHEMA} \${1:1.1}`,
         {
           label: "sample-gdrive",
           kind: monaco.languages.CompletionItemKind.Keyword,
-          insertText: `# Google Drive Sample
-${Keyword.TYPE} user
-${Keyword.TYPE} folder
-${SINGLE_INDENTATION}${Keyword.RELATIONS}
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}parent: [folder]
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}owner: [user]
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}editor: [user]
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}viewer: [user]
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_create_file: owner
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_delete: owner
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_edit: editor ${Keyword.OR} owner
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_view: viewer ${Keyword.OR} editor ${Keyword.OR} owner
-${Keyword.TYPE} folder
-${SINGLE_INDENTATION}${Keyword.RELATIONS}
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}parent: [folder]
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}owner: [user] or owner from parent
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}editor: [user] or editor from parent
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}viewer: [user] or viewer from parent
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_create_file: owner
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_delete: owner
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_edit: editor ${Keyword.OR} owner
-${SINGLE_INDENTATION}${SINGLE_INDENTATION}${Keyword.DEFINE}can_view: viewer ${Keyword.OR} editor ${Keyword.OR} owner`,
+          insertText: DefaultOneDotOneModel,
           range,
         },
       ],


### PR DESCRIPTION
## Description
Make available default 1.1 model for import by user of package

## References
N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
