### PR TITLE
fix: allow ttu relation as long as one of the child has such relation

### DIFF
--- a/src/validator/check-dsl.ts
+++ b/src/validator/check-dsl.ts
@@ -297,6 +297,7 @@ function childDefDefined(
         } else {
           const [fromTypes, isValid] = allowableTypes(transformedTypes, type, childDef.from);
           if (isValid) {
+            const childRelationNotValid = [];
             for (const item of fromTypes) {
               const { decodedType, decodedRelation, isWildcard } = destructTupleToUserset(item);
               if (isWildcard && decodedRelation) {
@@ -315,16 +316,24 @@ function childDefDefined(
                   value: childDef.from,
                 });
               } else {
+                // check to see if the relation is defined in any children
                 if (!transformedTypes[decodedType] || !transformedTypes[decodedType].relations[childDef.target]) {
                   const typeIndex = getTypeLineNumber(type, lines);
                   const lineIndex = getRelationLineNumber(relation, lines, typeIndex);
-                  reporter.invalidTypeRelation({
+                  childRelationNotValid.push({
                     lineIndex,
                     value: `${childDef.target} from ${childDef.from}`,
                     typeName: decodedType,
                     relationName: childDef.target,
                   });
                 }
+              }
+            }
+            // if all the children does not have this relation defined, we should raise error.
+            // otherwise, the relation is defined in at least 1 child and should be considered valid
+            if (childRelationNotValid.length === fromTypes.length) {
+              for (const item of childRelationNotValid) {
+                reporter.invalidTypeRelation(item);
               }
             }
           } else {

--- a/src/validator/check-dsl.ts
+++ b/src/validator/check-dsl.ts
@@ -329,7 +329,7 @@ function childDefDefined(
                 }
               }
             }
-            // if all the children does not have this relation defined, we should raise error.
+            // if none of the children have this relation defined, we should raise error.
             // otherwise, the relation is defined in at least 1 child and should be considered valid
             if (childRelationNotValid.length === fromTypes.length) {
               for (const item of childRelationNotValid) {

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -1176,6 +1176,83 @@ type user
     expectedError: [],
   },
   {
+    name: "model 1.1 should raise error if none of the children has such relation",
+    friendly: `model
+  schema 1.1
+type final
+  relations
+    define children: [child1, child2]
+    define has_assigned: u3 from children or u2 from children
+type child1
+  relations
+    define role: [user]
+    define u1: role
+type child2
+  relations
+    define role: [user]
+    define u4: role
+type user
+    `,
+    expectedError: [
+      {
+        endColumn: 42,
+        endLineNumber: 6,
+        extraInformation: {
+          error: "invalid-relation-type",
+          relation: "u3",
+          typeName: "child1",
+        },
+        message: "`u3` is not a valid relation for `child1`.",
+        severity: 8,
+        source: "linter",
+        startColumn: 26,
+        startLineNumber: 6,
+      },
+      {
+        endColumn: 42,
+        endLineNumber: 6,
+        extraInformation: {
+          error: "invalid-relation-type",
+          relation: "u3",
+          typeName: "child2",
+        },
+        message: "`u3` is not a valid relation for `child2`.",
+        severity: 8,
+        source: "linter",
+        startColumn: 26,
+        startLineNumber: 6,
+      },
+      {
+        endColumn: 62,
+        endLineNumber: 6,
+        extraInformation: {
+          error: "invalid-relation-type",
+          relation: "u2",
+          typeName: "child1",
+        },
+        message: "`u2` is not a valid relation for `child1`.",
+        severity: 8,
+        source: "linter",
+        startColumn: 46,
+        startLineNumber: 6,
+      },
+      {
+        endColumn: 62,
+        endLineNumber: 6,
+        extraInformation: {
+          error: "invalid-relation-type",
+          relation: "u2",
+          typeName: "child2",
+        },
+        message: "`u2` is not a valid relation for `child2`.",
+        severity: 8,
+        source: "linter",
+        startColumn: 46,
+        startLineNumber: 6,
+      },
+    ],
+  },
+  {
     name: "model 1.1 wildcard restricted type",
     friendly: `model
   schema 1.1

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -1156,6 +1156,26 @@ type user
     expectedError: [],
   },
   {
+    name: "model 1.1 allow TTU with relations as long as 1 child has such relation",
+    friendly: `model
+  schema 1.1
+type final
+  relations
+    define children: [child1, child2]
+    define has_assigned: u1 from children or u2 from children
+type child1
+  relations
+    define role: [user]
+    define u1: role
+type child2
+  relations
+    define role: [user]
+    define u2: role
+type user
+    `,
+    expectedError: [],
+  },
+  {
     name: "model 1.1 wildcard restricted type",
     friendly: `model
   schema 1.1


### PR DESCRIPTION

## Description
Relax model validation such that TTU relation is valid as long as one of the child has such relation

## References
Close https://github.com/openfga/syntax-transformer/issues/113


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
