### PR TITLE
fix: DSL should not allow schema version not specified

### DIFF
--- a/src/parser/openfga.ne
+++ b/src/parser/openfga.ne
@@ -1,25 +1,7 @@
 @preprocessor typescript
 
-types           ->  (types_10 | types_10_defined | types_11) {%
+types           ->  (types_10_defined | types_11) {%
      data => {return (data[0][0]) ? data[0][0]: (data[0][1]) ? data[0][1] : data[0][2]}
-%}
-
-types_10           ->   (_newline):* (type (_relations (_multiline_comment define_10):+):*):* {%
-    // @ts-ignore
-    (data) => {
-        // @ts-ignore
-        const types = data[1].map((datum) => {
-            // @ts-ignore
-            const relations = (datum[1] && datum[1][0] && datum[1][0][1].map(innerDatum => innerDatum[1])) || [];
-
-            return { ...datum[0], relations }
-        })
-
-        // @ts-ignore
-        const schemaVersion = "1.0";
-
-        return {types: types, schemaVersion: schemaVersion}
-    }
 %}
 
 types_10_defined ->   (_newline):* model_schema_10 (type (_relations (_multiline_comment define_10):+):*):* {%

--- a/tests/__snapshots__/dsl.test.ts.snap
+++ b/tests/__snapshots__/dsl.test.ts.snap
@@ -4,7 +4,7 @@ exports[`DSL checkDSL() invalid code should handle \`no definitions\` 1`] = `
 [
   {
     "endColumn": 9007199254740991,
-    "endLineNumber": 2,
+    "endLineNumber": 4,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
@@ -20,12 +20,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`and\` 1`] = `
 [
   {
     "endColumn": 37,
-    "endLineNumber": 4,
+    "endLineNumber": 6,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 29,
-    "startLineNumber": 4,
+    "startLineNumber": 6,
   },
 ]
 `;
@@ -34,12 +34,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`as\` 1`] = `
 [
   {
     "endColumn": 26,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 20,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -48,12 +48,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`as\` 2`] = `
 [
   {
     "endColumn": 26,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 20,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -62,12 +62,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`but not\` 1`] =
 [
   {
     "endColumn": 41,
-    "endLineNumber": 4,
+    "endLineNumber": 6,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 33,
-    "startLineNumber": 4,
+    "startLineNumber": 6,
   },
 ]
 `;
@@ -76,12 +76,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`define\` 1`] = 
 [
   {
     "endColumn": 27,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 7,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -90,12 +90,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`or\` 1`] = `
 [
   {
     "endColumn": 36,
-    "endLineNumber": 4,
+    "endLineNumber": 6,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 28,
-    "startLineNumber": 4,
+    "startLineNumber": 6,
   },
 ]
 `;
@@ -104,12 +104,12 @@ exports[`DSL checkDSL() invalid keywords should handle invalid \`self\` 1`] = `
 [
   {
     "endColumn": 26,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 25,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -126,7 +126,7 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
 [
   {
     "endColumn": 28,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "self-error",
     },
@@ -134,11 +134,11 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     "severity": 8,
     "source": "linter",
     "startColumn": 22,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
   {
     "endColumn": 33,
-    "endLineNumber": 5,
+    "endLineNumber": 7,
     "extraInformation": {
       "error": "missing-definition",
       "relation": "relation2",
@@ -147,11 +147,11 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     "severity": 8,
     "source": "linter",
     "startColumn": 24,
-    "startLineNumber": 5,
+    "startLineNumber": 7,
   },
   {
     "endColumn": 33,
-    "endLineNumber": 5,
+    "endLineNumber": 7,
     "extraInformation": {
       "error": "invalid-syntax",
     },
@@ -159,11 +159,11 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     "severity": 8,
     "source": "linter",
     "startColumn": 24,
-    "startLineNumber": 5,
+    "startLineNumber": 7,
   },
   {
     "endColumn": 28,
-    "endLineNumber": 6,
+    "endLineNumber": 8,
     "extraInformation": {
       "error": "self-error",
     },
@@ -171,7 +171,7 @@ exports[`DSL checkDSL() semantics should be able to handle more than one error 1
     "severity": 8,
     "source": "linter",
     "startColumn": 22,
-    "startLineNumber": 6,
+    "startLineNumber": 8,
   },
 ]
 `;
@@ -180,12 +180,12 @@ exports[`DSL checkDSL() semantics should gracefully handle error 1`] = `
 [
   {
     "endColumn": 7,
-    "endLineNumber": 15,
+    "endLineNumber": 17,
     "message": "Invalid syntax",
     "severity": 8,
     "source": "linter",
     "startColumn": 0,
-    "startLineNumber": 15,
+    "startLineNumber": 17,
   },
 ]
 `;
@@ -194,7 +194,7 @@ exports[`DSL checkDSL() semantics should handle duplicated definition 1`] = `
 [
   {
     "endColumn": 26,
-    "endLineNumber": 4,
+    "endLineNumber": 6,
     "extraInformation": {
       "error": "duplicated-error",
     },
@@ -202,7 +202,7 @@ exports[`DSL checkDSL() semantics should handle duplicated definition 1`] = `
     "severity": 8,
     "source": "linter",
     "startColumn": 5,
-    "startLineNumber": 4,
+    "startLineNumber": 6,
   },
 ]
 `;
@@ -211,7 +211,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid and\` 1`] = `
 [
   {
     "endColumn": 37,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "missing-definition",
       "relation": "reader",
@@ -220,7 +220,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid and\` 1`] = `
     "severity": 8,
     "source": "linter",
     "startColumn": 31,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -229,7 +229,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid but not\` 1`] 
 [
   {
     "endColumn": 41,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "missing-definition",
       "relation": "reader",
@@ -238,7 +238,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid but not\` 1`] 
     "severity": 8,
     "source": "linter",
     "startColumn": 35,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -247,7 +247,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid from\` 1`] = `
 [
   {
     "endColumn": 36,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "missing-definition",
       "relation": "reader",
@@ -256,11 +256,11 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid from\` 1`] = `
     "severity": 8,
     "source": "linter",
     "startColumn": 30,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
   {
     "endColumn": 46,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "invalid-syntax",
     },
@@ -268,7 +268,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid from\` 1`] = `
     "severity": 8,
     "source": "linter",
     "startColumn": 42,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -277,7 +277,7 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid or\` 1`] = `
 [
   {
     "endColumn": 36,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "missing-definition",
       "relation": "reader",
@@ -286,82 +286,12 @@ exports[`DSL checkDSL() semantics should handle invalid \`invalid or\` 1`] = `
     "severity": 8,
     "source": "linter",
     "startColumn": 30,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
 
 exports[`DSL checkDSL() semantics should handle invalid \`relation not define\` 1`] = `
-[
-  {
-    "endColumn": 28,
-    "endLineNumber": 3,
-    "extraInformation": {
-      "error": "missing-definition",
-      "relation": "reader",
-    },
-    "message": "The relation \`reader\` does not exist.",
-    "severity": 8,
-    "source": "linter",
-    "startColumn": 22,
-    "startLineNumber": 3,
-  },
-]
-`;
-
-exports[`DSL checkDSL() semantics should handle invalid \`relation not define\` where name is substring of other word 1`] = `
-[
-  {
-    "endColumn": 25,
-    "endLineNumber": 3,
-    "extraInformation": {
-      "error": "missing-definition",
-      "relation": "def",
-    },
-    "message": "The relation \`def\` does not exist.",
-    "severity": 8,
-    "source": "linter",
-    "startColumn": 22,
-    "startLineNumber": 3,
-  },
-]
-`;
-
-exports[`DSL checkDSL() semantics should handle invalid \`self-error\` 1`] = `
-[
-  {
-    "endColumn": 28,
-    "endLineNumber": 3,
-    "extraInformation": {
-      "error": "self-error",
-    },
-    "message": "For auto-referencing use 'self'.",
-    "severity": 8,
-    "source": "linter",
-    "startColumn": 22,
-    "startLineNumber": 3,
-  },
-]
-`;
-
-exports[`DSL checkDSL() semantics should handle invalid \`self-ref in but not\` 1`] = `
-[
-  {
-    "endColumn": 41,
-    "endLineNumber": 3,
-    "extraInformation": {
-      "error": "self-error",
-    },
-    "message": "For auto-referencing use 'self'.",
-    "severity": 8,
-    "source": "linter",
-    "startColumn": 35,
-    "startLineNumber": 3,
-  },
-]
-`;
-
-exports[`DSL checkDSL() semantics should identify correct error line number if there are spaces 1`] = `
 [
   {
     "endColumn": 28,
@@ -379,11 +309,81 @@ exports[`DSL checkDSL() semantics should identify correct error line number if t
 ]
 `;
 
+exports[`DSL checkDSL() semantics should handle invalid \`relation not define\` where name is substring of other word 1`] = `
+[
+  {
+    "endColumn": 25,
+    "endLineNumber": 5,
+    "extraInformation": {
+      "error": "missing-definition",
+      "relation": "def",
+    },
+    "message": "The relation \`def\` does not exist.",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 22,
+    "startLineNumber": 5,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`self-error\` 1`] = `
+[
+  {
+    "endColumn": 28,
+    "endLineNumber": 5,
+    "extraInformation": {
+      "error": "self-error",
+    },
+    "message": "For auto-referencing use 'self'.",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 22,
+    "startLineNumber": 5,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should handle invalid \`self-ref in but not\` 1`] = `
+[
+  {
+    "endColumn": 41,
+    "endLineNumber": 5,
+    "extraInformation": {
+      "error": "self-error",
+    },
+    "message": "For auto-referencing use 'self'.",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 35,
+    "startLineNumber": 5,
+  },
+]
+`;
+
+exports[`DSL checkDSL() semantics should identify correct error line number if there are spaces 1`] = `
+[
+  {
+    "endColumn": 28,
+    "endLineNumber": 7,
+    "extraInformation": {
+      "error": "missing-definition",
+      "relation": "reader",
+    },
+    "message": "The relation \`reader\` does not exist.",
+    "severity": 8,
+    "source": "linter",
+    "startColumn": 22,
+    "startLineNumber": 7,
+  },
+]
+`;
+
 exports[`DSL checkDSL() semantics should not allow impossible self reference 1`] = `
 [
   {
     "endColumn": 40,
-    "endLineNumber": 3,
+    "endLineNumber": 5,
     "extraInformation": {
       "error": "invalid-syntax",
     },
@@ -391,7 +391,7 @@ exports[`DSL checkDSL() semantics should not allow impossible self reference 1`]
     "severity": 8,
     "source": "linter",
     "startColumn": 34,
-    "startLineNumber": 3,
+    "startLineNumber": 5,
   },
 ]
 `;
@@ -400,7 +400,7 @@ exports[`DSL checkDSL() semantics should not allow self reference in from relati
 [
   {
     "endColumn": 57,
-    "endLineNumber": 4,
+    "endLineNumber": 6,
     "extraInformation": {
       "error": "invalid-syntax",
     },
@@ -408,7 +408,7 @@ exports[`DSL checkDSL() semantics should not allow self reference in from relati
     "severity": 8,
     "source": "linter",
     "startColumn": 47,
-    "startLineNumber": 4,
+    "startLineNumber": 6,
   },
 ]
 `;

--- a/tests/data/model-validation.ts
+++ b/tests/data/model-validation.ts
@@ -98,7 +98,9 @@ type group
   },
   {
     name: "cannot use this in mode 1.0",
-    friendly: `type document
+    friendly: `model
+  schema 1.0
+type document
   relations
     define editor as self
     define viewer as editor or this
@@ -106,7 +108,7 @@ type group
     expectedError: [
       {
         endColumn: 36,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "The relation `this` does not exist.",
         extraInformation: {
           relation: "this",
@@ -115,7 +117,7 @@ type group
         severity: 8,
         source: "linter",
         startColumn: 32,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
@@ -171,7 +173,9 @@ type org
   },
   {
     name: "ensure errors are highlighted in the right place for same relation name across different types",
-    friendly: `type user
+    friendly: `model
+  schema 1.0
+type user
 type geography
   relations
     define parent as self
@@ -185,7 +189,7 @@ type outlet
     expectedError: [
       {
         endColumn: 72,
-        endLineNumber: 10,
+        endLineNumber: 12,
         message: "The relation `parent` does not exist in type `outlet`",
         extraInformation: {
           error: "invalid-syntax",
@@ -193,7 +197,7 @@ type outlet
         severity: 8,
         source: "linter",
         startColumn: 66,
-        startLineNumber: 10,
+        startLineNumber: 12,
       },
     ],
   },
@@ -867,7 +871,9 @@ type org
   },
   {
     name: "model 1.0 should not have allowedType",
-    friendly: `type user
+    friendly: `model
+  schema 1.0
+type user
 type org
   relations
     define member: [user]
@@ -875,12 +881,12 @@ type org
     expectedError: [
       {
         endColumn: 25,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 18,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
@@ -908,7 +914,9 @@ type folder
   },
   {
     name: "model 1.0 should not have directly allowed types in viewer",
-    friendly: `type user
+    friendly: `model
+  schema 1.0
+type user
 type folder
   relations
     define parent: [folder]
@@ -917,12 +925,12 @@ type folder
     expectedError: [
       {
         endColumn: 27,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 18,
-        startLineNumber: 4,
+        startLineNumber: 6,
       },
     ],
   },
@@ -950,7 +958,9 @@ type folder
   },
   {
     name: "syntax error is highlighted in the right spot",
-    friendly: `type user
+    friendly: `model
+  schema 1.0
+type user
 type group
   relations
     define group: [group] as self
@@ -958,12 +968,32 @@ type group
     expectedError: [
       {
         endColumn: 33,
-        endLineNumber: 4,
+        endLineNumber: 6,
         message: "Invalid syntax",
         severity: 8,
         source: "linter",
         startColumn: 17,
-        startLineNumber: 4,
+        startLineNumber: 6,
+      },
+    ],
+  },
+
+  {
+    name: "should not allow no model schema",
+    friendly: `type user
+type group
+  relations
+    define group: [user] as self
+`,
+    expectedError: [
+      {
+        endColumn: 9,
+        endLineNumber: 1,
+        message: "Invalid syntax",
+        severity: 8,
+        source: "linter",
+        startColumn: 1,
+        startLineNumber: 1,
       },
     ],
   },
@@ -991,7 +1021,9 @@ type group
   // The following are valid cases and should not result in error
   {
     name: "simple model 1.0",
-    friendly: `type user
+    friendly: `model
+  schema 1.0
+type user
 type group
   relations
     define member as self
@@ -1131,7 +1163,9 @@ type group
   },
   {
     name: "model 1.0 does not assert impossible relation",
-    friendly: `type user
+    friendly: `model
+  schema 1.0
+type user
 type folder
   relations
     define parent as self

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -5,13 +5,17 @@ import { ValidationOptions } from "../src/validator";
 describe("DSL", () => {
   describe("parseDSL()", () => {
     it("should correctly parse a type with no relations", () => {
-      const result = parseDSL("type group");
+      const result = parseDSL(`model
+  schema 1.0
+type group`);
 
       expect(result).toMatchSnapshot();
     });
 
     it("should correctly parse a simple sample", () => {
-      const result = parseDSL(`type group
+      const result = parseDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self`);
 
@@ -19,7 +23,9 @@ describe("DSL", () => {
     });
 
     it("should correctly parse a complex sample", () => {
-      const result = parseDSL(`type team
+      const result = parseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
 
@@ -52,7 +58,9 @@ type app
 
   describe("innerParseDSL()", () => {
     it("should only return single result for simple valid model", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define other as self
@@ -61,7 +69,9 @@ type app
     });
 
     it("should only return single result for simple valid model with spaces", () => {
-      const result = innerParseDSL(`type team   
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations   
     define member as self 
     define    other   as   self  
@@ -70,7 +80,9 @@ type app
     });
 
     it("should only return single result for simple valid model with non direct result", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define other as member
@@ -79,7 +91,9 @@ type app
     });
 
     it("should only return single result for simple valid model with non direct result and spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define other as  member  
@@ -88,7 +102,9 @@ type app
     });
 
     it("should only return single result for simple valid model with intersection", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define myfriend as self
@@ -98,7 +114,9 @@ type app
     });
 
     it("should only return single result for simple valid model with intersection and spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define other as self   or   member   or myfriend    
@@ -107,7 +125,9 @@ type app
     });
 
     it("should only return single result for simple valid model with union", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define myfriend as self
@@ -117,7 +137,9 @@ type app
     });
 
     it("should only return single result for simple valid model with union and spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define myfriend as self
@@ -127,7 +149,9 @@ type app
     });
 
     it("should only return single result for simple valid model with but not", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define other as self but not member
@@ -136,7 +160,9 @@ type app
     });
 
     it("should only return single result for simple valid model with but not and spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define other as self   but not   member   
@@ -145,7 +171,9 @@ type app
     });
 
     it("should only return single result for simple valid model with tuple to userset", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define viewer as self
     define parent as self
@@ -155,7 +183,9 @@ type app
     });
 
     it("should only return single result for simple valid model with tuple to userset and spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define viewer as self
     define parent as self
@@ -165,7 +195,9 @@ type app
     });
 
     it("should only return single result for simple valid model with but not + tuple to userset", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define parent as self
@@ -176,7 +208,9 @@ type app
     });
 
     it("should only return single result for simple valid model with but not + tuple to userset and spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
     define parent as self
@@ -187,7 +221,9 @@ type app
     });
 
     it("should only return single result for simple valid model with multiple types", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define viewer as self
 type group
@@ -198,7 +234,9 @@ type group
     });
 
     it("should only return single result for simple valid model with multiple types and empty lines", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define viewer as self
 
@@ -211,7 +249,9 @@ type group
     });
 
     it("should only return single result for simple valid model with multiple types and empty lines + spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define viewer as self
       
@@ -274,7 +314,9 @@ type team
     });
 
     it("should only return single result for complex valid model", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
 
@@ -305,7 +347,9 @@ type app
     });
 
     it("should only return single result for complex model with spaces", () => {
-      const result = innerParseDSL(`type team
+      const result = innerParseDSL(`model
+  schema 1.0
+type team
   relations
     define member as self
 
@@ -386,7 +430,9 @@ type app
 
     it("should parse DSL in reasonable time", () => {
       // Add in addition `define R as X from Y but not Z` to increase the time
-      const result = innerParseDSL(`type T1
+      const result = innerParseDSL(`model
+  schema 1.0
+type T1
   relations
     define A as A1 from A2 but not A3
     define B as B1 from B2 but not B3
@@ -455,7 +501,9 @@ type T5
 
   describe("checkDSL()", () => {
     it("should correctly parse a simple sample", () => {
-      const markers = checkDSL(`type group
+      const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define member as self
 
@@ -472,12 +520,16 @@ type document
 
     describe("invalid code", () => {
       it("should handle `no relations`", () => {
-        const markers = checkDSL("type group");
+        const markers = checkDSL(`model
+  schema 1.0
+type group`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle `no definitions`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations`);
         expect(markers).toMatchSnapshot();
       });
@@ -485,35 +537,45 @@ type document
 
     describe("invalid keywords", () => {
       it("should handle invalid `self`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as se lf`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `as`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer a s self`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `define`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     dec lare writer as self`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `as`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer a s self`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `or`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define reader as self
     define writer as self o r reader`);
@@ -521,7 +583,9 @@ type document
       });
 
       it("should handle invalid `and`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define reader as self
     define writer as self an d reader`);
@@ -529,7 +593,9 @@ type document
       });
 
       it("should handle invalid `but not`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define reader as self
     define writer as self but no t reader`);
@@ -539,28 +605,36 @@ type document
 
     describe("semantics", () => {
       it("should handle invalid `self-error`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as writer`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `relation not define`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as reader`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `relation not define` where name is substring of other word", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as def`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should identify correct error line number if there are spaces", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
 
     define owner as self
@@ -569,42 +643,54 @@ type document
       });
 
       it("should handle invalid `self-ref in but not`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self but not writer`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `invalid but not`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self but not reader`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `invalid from`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self or reader from test`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `invalid or`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self or reader`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle invalid `invalid and`", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self and reader`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should handle duplicated definition", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as self
     define writer as self`);
@@ -612,7 +698,9 @@ type document
       });
 
       it("should be able to handle more than one error", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define writer as writer
     define hi as self
@@ -622,7 +710,9 @@ type document
       });
 
       it("should allow reference from other relation", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define foo as self
     define member as self or member from foo`);
@@ -630,14 +720,18 @@ type document
       });
 
       it("should allow self reference", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define member as self or member from member`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should allow same relation name in from", () => {
-        const markers = checkDSL(`type feature
+        const markers = checkDSL(`model
+  schema 1.0
+type feature
   relations
     define associated_plan as self
     define subscriber as subscriber from associated_plan`);
@@ -645,7 +739,9 @@ type document
       });
 
       it("should not allow self reference in from relation", () => {
-        const markers = checkDSL(`type feature
+        const markers = checkDSL(`model
+  schema 1.0
+type feature
   relations
     define associated_plan as self
     define subscriber as associated_plan from subscriber`);
@@ -653,14 +749,18 @@ type document
       });
 
       it("should not allow impossible self reference", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define member as member from member`);
         expect(markers).toMatchSnapshot();
       });
 
       it("should allow model with relations starting with as", () => {
-        const markers = checkDSL(`type org
+        const markers = checkDSL(`model
+  schema 1.0
+type org
   relations
     define member as self
 type feature
@@ -679,7 +779,9 @@ type permission
       });
 
       it("should gracefully handle error", () => {
-        const markers = checkDSL(`type group
+        const markers = checkDSL(`model
+  schema 1.0
+type group
   relations
     define member as self
     define admin as self

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,13 +4,17 @@ describe("friendlySyntaxToApiSyntax()", () => {
   describe("invalid syntax", () => {
     it("should throw if syntax is incorrect", () => {
       expect(() => {
-        friendlySyntaxToApiSyntax("t ype t1");
+        friendlySyntaxToApiSyntax(`model
+  schema 1.0
+t ype t1`);
       }).toThrowError();
     });
 
     it("should throw if syntax is incorrect", () => {
       expect(() => {
-        friendlySyntaxToApiSyntax(`type test
+        friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type test
   relations
     define writer as self and a but not test`);
       }).toThrowError();
@@ -18,7 +22,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
 
     it("should throw if syntax is incorrect", () => {
       expect(() => {
-        friendlySyntaxToApiSyntax(`type test
+        friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type test
   relations
     define writer as self and pepe or test `);
       }).toThrowError();
@@ -26,7 +32,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should correctly read from `basic` definition", () => {
-    const result = friendlySyntaxToApiSyntax(`type t1
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type t1
   relations
     define r1 as self
 `);
@@ -42,7 +50,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should be able to handle single character type", () => {
-    const result = friendlySyntaxToApiSyntax(`type t
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type t
   relations
     define r as self
 `);
@@ -58,7 +68,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should correctly read from `and` definition", () => {
-    const result = friendlySyntaxToApiSyntax(`type t1
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type t1
   relations
     define r1 as self and writer
 `);
@@ -83,7 +95,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should correctly read from `and` definition with $ as prefix", () => {
-    const result = friendlySyntaxToApiSyntax(`type $t1
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type $t1
   relations
     define $r1 as self and $writer
 `);
@@ -107,7 +121,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should correctly read from `or` definition", () => {
-    const result = friendlySyntaxToApiSyntax(`type t1
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type t1
   relations
     define r1 as self or writer
 `);
@@ -132,7 +148,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should correctly read from `but not` definition", () => {
-    const result = friendlySyntaxToApiSyntax(`type t1
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type t1
   relations
     define r1 as self but not writer
 `);
@@ -154,7 +172,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should correctly read from `from` definition", () => {
-    const result = friendlySyntaxToApiSyntax(`type t1
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type t1
   relations
     define share as owner from parent
 `);
@@ -164,7 +184,9 @@ describe("friendlySyntaxToApiSyntax()", () => {
   });
 
   it("should read a complex definition 1", () => {
-    const result = friendlySyntaxToApiSyntax(`type folder
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type folder
   relations
     define deleter as self
 type doc
@@ -185,7 +207,9 @@ type doc
   });
 
   it("should read a complex definition 2", () => {
-    const result = friendlySyntaxToApiSyntax(`type website
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type website
   relations
     define admin as self or owner
     define billing as self or admin
@@ -199,7 +223,9 @@ type doc
   });
 
   it("should read a complex definition 3", () => {
-    const result = friendlySyntaxToApiSyntax(`type website
+    const result = friendlySyntaxToApiSyntax(`model
+  schema 1.0
+type website
   relations
     define admin as self or randy
     define billing as self or admin


### PR DESCRIPTION
## Description
If the model schema is not defined in DSL, we should not assume it is 1.0

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
