### PR TITLE
fix(ci): enforce patched axios version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "homepage": "https://github.com/openfga/frontend-utils#readme",
   "overrides": {
+    "axios": "1.18.1",
     "dompurify": "^3.4.11"
   },
   "engines": {


### PR DESCRIPTION
Fixes the failing audit check in #376.

`npm audit --no-package-lock` does not use the Axios version resolved in `package-lock.json`; it resolves `@openfga/sdk` through its semver range and detects its vulnerable Axios dependency. This adds a root override for Axios 1.18.1, so the audit respects the patched version.

Verified with Node 24.18.0 and npm 11.16.0:
- `npm audit --no-package-lock`
- `npm run build`
- `npm run format:check`
- `npm run lint`
- `npm test` (58 passing)